### PR TITLE
scale line heights for h2/h3 + fix em bug

### DIFF
--- a/styles/designs/webview/parts/_caption-components.scss
+++ b/styles/designs/webview/parts/_caption-components.scss
@@ -64,7 +64,7 @@ $Caption__Container--Table: (
     border-top-width: 0.1rem,
     border-top-style: solid,
     border-top-color: enum('ValueSet:::REQUIRED'),
-    font-size: scaled_size(0.9em),
+    font-size: 0.9em,
   )
 );
 

--- a/styles/designs/webview/parts/_titles-components.scss
+++ b/styles/designs/webview/parts/_titles-components.scss
@@ -21,6 +21,7 @@ $H2: (
     color: enum('ValueSet:::REQUIRED'),
     font-size: scaled_size(3.2rem),
     margin: '1.5rem 0 1rem 0',
+    line-height: scaled_size(4rem),
     font-weight: bold,
   )
 );
@@ -60,6 +61,7 @@ $H3: (
   _properties: (
     color: enum('ValueSet:::REQUIRED'),
     font-size: scaled_size(2.4rem),
+    line-height: scaled_size(3rem),
     margin: '1.5rem 0 1rem 0',
     font-weight: bold,
   )


### PR DESCRIPTION
Adds a default line-height for h2 and h3 to prevent wrapped text from appearing vertically squished:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/34174/171948408-7c8d1c69-de4a-4b68-a7c2-adc638ed067b.png) | ![image](https://user-images.githubusercontent.com/34174/171948309-0be61a61-d609-46b5-97b3-ef9043e833a8.png)

Also fixes a bug with accidentally scaling an `em`.