### PR TITLE
Add break to build-styles and build-impacted-styles

### DIFF
--- a/script/build-impacted-styles
+++ b/script/build-impacted-styles
@@ -28,5 +28,8 @@ for i in "${!book_files[@]}"; do
     css_file="${output_dir}/${style_name}-pdf.css"
 
     echo "Generating ${css_file} $((i + 1))/${#book_files[@]}"
-    dart styles/build/build.dart "${sass_file}" "${css_file}"
+    dart styles/build/build.dart "${sass_file}" "${css_file}" || {
+      echo "Generating ${css_file} failed"
+      break
+    }
 done

--- a/script/build-styles
+++ b/script/build-styles
@@ -28,7 +28,10 @@ for i in "${!STYLE_NAMES[@]}"; do
   css_file="${output_dir}/${style_name}-pdf.css"
 
   echo "Generating ${css_file} $((i + 1))/${#STYLE_NAMES[@]}"
-  dart styles/build/build.dart "${sass_file}" "${css_file}"
+    dart styles/build/build.dart "${sass_file}" "${css_file}" || {
+      echo "Generating ${css_file} failed"
+      break
+    }
 
   #disable web styles for the time being
   #do_progress "Building webpackable _web-styles.json" \


### PR DESCRIPTION
[#4371](https://app.zenhub.com/workspaces/ce-styles-5cdc84baee941c07853fbbf2/issues/openstax/cnx-recipes/4371)

build-styles and build-impacted-styles will now stop running after a style it's building fails.