### PR TITLE
4830 Justify Root Text in Organic Chemistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Style `Learning Objectives` note in `pl-economics`
 * Fix settings for `ChapterObjectives` from `pl-economics`
 * Style exercises and Answer Key in `organic-chemistry`
+* Justify root text in `organic-chemistry`

--- a/styles/books/organic-chemistry/book.scss
+++ b/styles/books/organic-chemistry/book.scss
@@ -17,6 +17,7 @@ $ChapterIntroType: fullWidth;
     BookRoot: (
         _selectors: (":root"),
         'BookRoot:::font-family': (_ref: 'typography:::baseOption2Font'),
+        'BookRoot:::text-align': justify,
     ),
 ));
 

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -5,6 +5,7 @@ $bookRoot:(
     font-family: enum('ValueSet:::REQUIRED'), ///default font family for book
     font-size: enum('ValueSet:::REQUIRED'), //base font size
     line-height: enum('ValueSet:::REQUIRED'), //base line height
+    text-align: enum('ValueSet:::OPTIONAL'), // To justify organic chemistry text
     color: enum('ValueSet:::REQUIRED'),
     prince-image-resolution: enum('ValueSet:::REQUIRED'),
     prince-background-image-resolution: enum('ValueSet:::REQUIRED')

--- a/styles/output/organic-chemistry-pdf.css
+++ b/styles/output/organic-chemistry-pdf.css
@@ -892,6 +892,7 @@ div[data-type=composite-page].os-eob {
   font-family: IBM Plex Serif, serif;
   font-size: 12px;
   line-height: 1.4rem;
+  text-align: justify;
   color: #000000;
   prince-image-resolution: auto, 200dpi;
   prince-background-image-resolution: 200dpi;


### PR DESCRIPTION
[#4830](https://github.com/openstax/cnx-recipes/issues/4830)


Acceptance Criteria: 
Justifies the root text in organic-chemistry, text-align not touched in any of the other books. 

Locations:
repo: openstax/osbooks-organic-chemistry
slug: organic-chemistry
ref: Design-Chapter
Chapter: Any, root text