### PR TITLE
Remove Key Equations Table Spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Remove spaces between tables in Key Equations subsections in `cardboard`
 * Change way of displaying `mechanism-figures` in `organic-chemistry`
 * Update `ColoredText` selectors in Accounting and Marketing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Remove spaces between tables in Key Equations subsections in `cardboard`
+* Remove spaces between tables in Key Equations subsections in `corn`
 * Change way of displaying `mechanism-figures` in `organic-chemistry`
 * Update `ColoredText` selectors in Accounting and Marketing
 

--- a/styles/books/calculus/book.scss
+++ b/styles/books/calculus/book.scss
@@ -116,6 +116,9 @@ $bandColor: #093D4C;
   AnswerKeyExercisesSolutionLists: (
     _selectors: ('.os-eob.os-solutions-container [data-type="solution"]'),
   ),
+  KeyEquations:(
+      _selectors: (".os-key-equations-container"),
+  ),
 ));
 
 @include add_settings((
@@ -198,6 +201,9 @@ $bandColor: #093D4C;
 
 //Section Exercises
 @include use('ThreeColumnsModuleExercises', 'corn:::ExercisesModuleShape');
+
+//Key Equations spacing
+@include use('KeyEquations','corn:::ModuleWithUnstyledTableShape');
 
 // EoC Exercises
 @include use('ReviewExercises', 'corn:::ExercisesModuleShape');

--- a/styles/designs/corn/parts/_lists-components.scss
+++ b/styles/designs/corn/parts/_lists-components.scss
@@ -12,6 +12,14 @@ $DivWrapper--FourthLevel: empty_wrapper(ThirdLevel, ' > div > div > div > div');
 
 $ParaWrapper--FirstLevel: empty_wrapper(FirstLevel, ' > p');
 
+$SectionWrapper--FirstLevelNoBottomMargin: (
+    _name: "FirstLevel",
+    _subselector: ' > section',
+    _properties:(
+        margin-bottom: 0,
+    )
+);
+
 // Basic Lists
 $UnorderedList--FirstLevel: (
     _name: "FirstLevelUnorderedList",

--- a/styles/designs/corn/parts/_module-shapes.scss
+++ b/styles/designs/corn/parts/_module-shapes.scss
@@ -31,7 +31,7 @@
     _components:(
         map-merge($Module__Container,(
             _components:(
-                map-merge($SectionWrapper--FirstLevel,(
+                map-merge($SectionWrapper--FirstLevelNoBottomMargin,(
                     _components:(
                         map-merge($Table__Container--ModuleWithUnstyledTable,(
                             _components:(

--- a/styles/designs/corn/parts/_module-shapes.scss
+++ b/styles/designs/corn/parts/_module-shapes.scss
@@ -24,3 +24,23 @@
         )),
     )
 ));
+
+// Used to remove extra spaces between tables in sections like Key-Equations in calculus
+
+@include create_shape('corn:::ModuleWithUnstyledTableShape',(
+    _components:(
+        map-merge($Module__Container,(
+            _components:(
+                map-merge($SectionWrapper--FirstLevel,(
+                    _components:(
+                        map-merge($Table__Container--ModuleWithUnstyledTable,(
+                            _components:(
+                                $Table--ModuleWithUnstyledTable,
+                            ),
+                        )),
+                    ),
+                )),
+            ),
+        )),
+    )
+));

--- a/styles/designs/corn/parts/_table-components.scss
+++ b/styles/designs/corn/parts/_table-components.scss
@@ -210,8 +210,8 @@ $Table--TopSpacing:(
     _properties: (
         margin-top: 1rem,
     )
-); 
-       
+);
+
 // Used in two columns modules
 $Table--FromTwoColumnsModule: (
     _name: "TableFromTwoColumnsModule",
@@ -220,5 +220,23 @@ $Table--FromTwoColumnsModule: (
       table-layout: fixed,
       max-width: 100%,
       break-inside: avoid-column,
+    )
+);
+
+// used for tables in same section like Key Equations in Calc
+
+$Table__Container--ModuleWithUnstyledTable: (
+    _name: "TableContainerModuleWithUnstyledTable",
+    _subselector: " > .os-table.os-unstyled-container",
+    _properties: (
+        margin-bottom: 0,
+    )
+);
+
+$Table--ModuleWithUnstyledTable: (
+    _name: "TableModuleWithUnstyledTable",
+    _subselector: " > table.unstyled",
+    _properties: (
+        margin-bottom: 0,
     )
 );

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -3548,6 +3548,14 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
+.os-key-equations-container > section > .os-table.os-unstyled-container {
+  margin-bottom: 0;
+}
+
+.os-key-equations-container > section > .os-table.os-unstyled-container > table.unstyled {
+  margin-bottom: 0;
+}
+
 .os-eoc.os-review-exercises-container > section.review-exercises > p > [data-effect=bold] {
   color: #1E7E91;
   font-family: Noto Sans, sans-serif, StixGeneral;

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -3548,6 +3548,10 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
+.os-key-equations-container > section {
+  margin-bottom: 0;
+}
+
 .os-key-equations-container > section > .os-table.os-unstyled-container {
   margin-bottom: 0;
 }


### PR DESCRIPTION
[#4720](https://github.com/openstax/cnx-recipes/issues/4720)

spaces between tables in Key Equations section removed in corn (found only in Calculus style)

![Screen Shot 2022-10-03 at 3 22 42 PM](https://user-images.githubusercontent.com/5740972/193674162-d57a93c8-5aa9-4157-90c7-d478536928b1.png)
