### PR TITLE
Answer Key Table Alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add Text-Align to `TableFromAnswerKey` in `corn`
 * Create separate shape for `TableFromAnswerKey` in `corn`
 * Create `IconIncreasedNoteShape` in `carnival`
 

--- a/styles/designs/corn/parts/_table-components.scss
+++ b/styles/designs/corn/parts/_table-components.scss
@@ -213,7 +213,7 @@ $Table__Data--AnswerKey: (
         border-color: enum('ValueSet:::REQUIRED'),
         color: enum('ValueSet:::REQUIRED'),
         vertical-align: top,
-        text-align: center
+        text-align: center,
     )
 );
 

--- a/styles/designs/corn/parts/_table-shapes.scss
+++ b/styles/designs/corn/parts/_table-shapes.scss
@@ -242,6 +242,9 @@
                               map-merge($Table__Row, (
                                 _components: (
                                   $Table__Data--AnswerKey,
+                                  $Table__Data--LeftAligned,
+                                  $Table__Data--RightAligned,
+                                  $Table__Data--Centered,
                                 )
                               )),
                             )

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -3373,6 +3373,18 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=left] {
+  text-align: left;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=right] {
+  text-align: right;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=center] {
+  text-align: center;
+}
+
 .os-glossary-container > dl {
   text-indent: -16px;
   padding-left: 16px;

--- a/styles/output/contemporary-math-pdf.css
+++ b/styles/output/contemporary-math-pdf.css
@@ -3276,6 +3276,18 @@ li > table {
   text-align: center;
 }
 
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=left] {
+  text-align: left;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=right] {
+  text-align: right;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=center] {
+  text-align: center;
+}
+
 .os-glossary-container > dl {
   text-indent: -16px;
   padding-left: 16px;

--- a/styles/output/dev-math-pdf.css
+++ b/styles/output/dev-math-pdf.css
@@ -3308,6 +3308,18 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=left] {
+  text-align: left;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=right] {
+  text-align: right;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=center] {
+  text-align: center;
+}
+
 .be-prepared {
   display: table;
   margin-bottom: 1.4rem;

--- a/styles/output/precalculus-coreq-pdf.css
+++ b/styles/output/precalculus-coreq-pdf.css
@@ -3142,6 +3142,18 @@ section.coreq-skills > section.learning-objectives > ul > li {
   text-align: center;
 }
 
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=left] {
+  text-align: left;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=right] {
+  text-align: right;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=center] {
+  text-align: center;
+}
+
 section.coreq-skills > p > [data-effect=bold] {
   font-size: 1rem;
   line-height: 1.5rem;

--- a/styles/output/precalculus-pdf.css
+++ b/styles/output/precalculus-pdf.css
@@ -3200,6 +3200,18 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=left] {
+  text-align: left;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=right] {
+  text-align: right;
+}
+
+.os-eob .os-solution-container .os-table > table > tbody > tr > td[data-align=center] {
+  text-align: center;
+}
+
 .how-to-notitle {
   margin-bottom: 1.4rem;
 }


### PR DESCRIPTION
[#4901](https://github.com/openstax/cnx-recipes/issues/4901)

Data-align attribute now overrides Answer Key tables' default center alignment

Aligned Left when data-align="left" is present:
![Screen Shot 2022-10-27 at 11 22 37 AM](https://user-images.githubusercontent.com/5740972/198345688-0caccbbf-3318-4104-94a4-09edd7fe3d45.png)

Aligned center when it isn't:
![Screen Shot 2022-10-27 at 11 22 53 AM](https://user-images.githubusercontent.com/5740972/198345707-f669bd0a-af0e-4a70-9ef1-66a9e4ff3da2.png)
