### PR TITLE
Cosmos ChapterObjectives list fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `cosmos` `ChapterObjectives` list font
 * Split lists shapes in `corn`
 * Fix column breaking in `AppendixGlossary` from `cosmos`
 * Move `UnitOpener` files to `common` directory

--- a/styles/design-settings/cosmos/parts/_objectiveoutline-settings.scss
+++ b/styles/design-settings/cosmos/parts/_objectiveoutline-settings.scss
@@ -53,10 +53,10 @@
           margin-bottom:v-spacing(1),
         ),
         Paragraph: (
-          font-family: (_ref: "typography:::titleOption2Font"),
+          font-family: (_ref: "typography:::baseFont"),
         ),
         ChapterObjectivesListItem: (
-          font-family: (_ref: "typography:::titleOption2Font"),
+          font-family: (_ref: "typography:::baseFont"),
         ),
     )
 ));

--- a/styles/output/economics-pdf.css
+++ b/styles/output/economics-pdf.css
@@ -1194,7 +1194,7 @@ nav#toc > ol > li.os-toc-chapter > ol.os-chapter > li > a::after {
 
 [data-type=note].economics.chapter-objectives > .os-note-body > p {
   margin-bottom: 0;
-  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-family: IBM Plex Serif, serif, StixGeneral;
 }
 
 [data-type=note].economics.chapter-objectives > .os-note-body > ul:not([data-labeled-item=true]) {

--- a/styles/output/pl-economics-pdf.css
+++ b/styles/output/pl-economics-pdf.css
@@ -1111,7 +1111,7 @@ nav#toc > ol > li.os-toc-chapter > ol.os-chapter > li > a::after {
 
 [data-type=note].economics.chapter-objectives > .os-note-body > p {
   margin-bottom: 0;
-  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-family: IBM Plex Serif, serif, StixGeneral;
 }
 
 [data-type=note].economics.chapter-objectives > .os-note-body > ul:not([data-labeled-item=true]) {


### PR DESCRIPTION
[#4922](https://github.com/openstax/cnx-recipes/issues/4922)

Fixes Cosmos Chapter Objectives to use the same base font for both <p> and list items.

![Screen Shot 2022-11-30 at 5 00 17 PM](https://user-images.githubusercontent.com/5740972/204926398-e085c3cb-a6a9-4b21-b508-55a840d7aa76.png)
