### PR TITLE
change behavior for unset REQUIRED settings from error to warning

### DIFF
--- a/styles/framework/settings/_init.scss
+++ b/styles/framework/settings/_init.scss
@@ -119,7 +119,9 @@ $FRAMEWORK_USED_SETTINGS: ();
   @if $default != enum('Object:::NONE') {
     @return $default;
   }
-  @return error(enum('Error:::INDEX_ERROR'), "Unknown setting `#{$name}`.");
+
+  @warn "Unknown setting `#{$name}`.";
+  @return "UNSET";
 }
 
 @function settings_not_null($name, $default: enum('Object:::NONE')) {


### PR DESCRIPTION
Currently, when `REQUIRED` settings are left unset in a `book` file, the styles framework will error out at the first instance it encounters.

It might be more useful to change this error to a warning, so that the compiler will keep running, & devs get a full log of unset settings (with less extra error noise) and can fix them all at once.

Comment below has examples of the current error behavior & proposed warning behavior.