### PR TITLE
new approach for styling folio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Create new approach for styling `folio`
 * Display `Answer Key` solutions inline in `organic-chemistry`
 
 ## [v1.127.0] - 2023-04-08

--- a/styles/books/organic-chemistry/book.scss
+++ b/styles/books/organic-chemistry/book.scss
@@ -11,7 +11,7 @@ $ChapterIntroType: fullWidth;
 @import 'framework/framework';
 @import '../../design-settings/carnival/_design.scss';
 @import '../../design-settings/carnival/_settings.scss';
-@import '../../designs/carnival/pdf/folio';
+@import '../../designs/carnival/pdf/folio_new';
 
 @include add_settings((
     BookRoot: (

--- a/styles/designs/carnival/pdf/_folio_new.scss
+++ b/styles/designs/carnival/pdf/_folio_new.scss
@@ -1,0 +1,198 @@
+// TODO: apply to all books and remove old file with folio
+
+@mixin folioStyles() {
+    font-size: font-scale(-1);
+    font-family: ('Mulish', sans-serif);
+    color: #A5A5A5; 
+    font-weight: 700;
+}
+
+@mixin parasWithBand($leftSelector, $rightSelector, $leftPosition, $rightPosition) {
+    #{$leftSelector} {
+        position: running(#{$leftPosition});
+        @include folioStyles();
+    }
+    
+    #{$leftSelector}::before { 
+        content: counter(page) "\00a0\00a0\00a0\00a0\00a0"; 
+    }
+    
+    #{$rightSelector} {
+        position: running(#{$rightPosition});
+        text-align: right;
+        @include folioStyles();
+    }
+    
+    #{$rightSelector}::after {
+        content: "\00a0\00a0\00a0\00a0\00a0" counter(page); 
+    }
+}
+
+// Paras
+p.folio-chapter {
+    position: running(folio_chapter);
+    @include folioStyles();
+}
+
+p.folio-module {
+    position: running(folio_module);
+    text-align: right;
+    @include folioStyles();
+}
+
+@include parasWithBand('p.folio-eoc-left', 'p.folio-eoc-right', folio_eoc_left, folio_eoc_right);
+@include parasWithBand('p.folio-appendix-left', 'p.folio-appendix-right', folio_appendix_left, folio_appendix_right);
+@include parasWithBand('p.folio-eob-left', 'p.folio-eob-right', folio_eob_left, folio_eob_right);
+
+
+//Page definitions
+nav#toc {
+    page: table-of-contents;
+}
+  
+div[data-type="page"].preface {
+    page: preface;
+    counter-reset: page 1;
+}
+
+.os-eoc {
+    page: eoc;
+}
+
+[data-type="chapter"] {
+    page: chapter;
+    prince-page-group: start;
+}
+
+div[data-type="page"].appendix {
+    page: appendix;
+}
+
+div[data-type="composite-page"].os-eob {
+    page: eob;
+}
+
+//Unnumbered pages
+@page chapter:first {
+    @top-left-corner {
+      content: none;
+    }
+    @top-right-corner {
+      content: none;
+    }
+    @top-left {
+      content: none;
+    }
+    @top-center {
+      content: none;
+    }
+    @top-right {
+      content: none;
+    }
+}
+
+@page table-of-contents {
+    @top-left-corner {
+      content: none;
+    }
+    @top-left {
+      content: none;
+    }
+    @top-right-corner {
+      content: none;
+    }
+    @top-right {
+      content: none;
+    }
+}
+
+@mixin folio($leftContent, $rightContent, $bottomContent, $page: null ) {
+    @page #{$page}:left {
+      @top-left {
+        content: $leftContent;
+        @include folioStyles();
+      }
+      @top-left-corner {
+        content: counter(page);
+        margin-right: h-spacing(5);
+        @include folioStyles();
+      }
+      @bottom-left {
+          content: $bottomContent;
+          @include folioStyles();
+      }
+    }
+  
+    @page #{$page}:right {
+      @top-right {
+        content: $rightContent;
+        @include folioStyles();
+      }
+      @top-right-corner {
+        content: counter(page);
+        margin-left: h-spacing(5);
+        @include folioStyles();
+      }
+    }
+}
+
+@mixin folioWithBand($leftContent, $rightContent, $bottomContent, $page) {
+    @page #{$page}:left {
+        @top-left {
+            content: $leftContent;
+            @include folioStyles();
+        }
+        @bottom-left {
+            content: $bottomContent;
+            @include folioStyles();
+        }
+    }
+  
+    @page #{$page}:right {
+        @top-right {
+            content: $rightContent;
+            @include folioStyles();
+        }
+    }
+}
+
+
+$defaultLeftContent: element(folio_chapter);
+$defaultRightContent: element(folio_module);
+
+$prefaceContent: string(preface-msg);
+$accessContent: string(access-for-free-msg);
+
+[data-pdf-folio-preface-message][data-pdf-folio-access-message] {
+  string-set: preface-msg attr(data-pdf-folio-preface-message) access-for-free-msg attr(data-pdf-folio-access-message); }
+
+$eocLeftContent: element(folio_eoc_left);
+$eocRightContent: element(folio_eoc_right);
+$appendixLeftContent: element(folio_appendix_left);
+$appendixRightContent: element(folio_appendix_right);
+$eobLeftContent: element(folio_eob_left);
+$eobRightContent: element(folio_eob_right);
+
+@include folio($defaultLeftContent, $defaultRightContent, $accessContent);
+@include folio($prefaceContent, $prefaceContent, $accessContent, preface );
+@include folioWithBand($eocLeftContent, $eocRightContent, $accessContent, eoc);
+@include folioWithBand($appendixLeftContent, $appendixRightContent, $accessContent, appendix);
+@include folioWithBand($eobLeftContent, $eobRightContent, $accessContent, eob);
+
+// Pages margins
+@page {
+  margin-left: 1in;
+  margin-right: 1in;
+  margin-bottom: 0.8in;
+  margin-top: 0.8in;
+}
+
+@if $ChapterIntroType == side {
+  @page chapter:first {
+    margin-right: 2in;
+  }
+  
+  @page chapter:nth(2) {
+    margin-right: 2in;
+  }
+}

--- a/styles/output/organic-chemistry-pdf.css
+++ b/styles/output/organic-chemistry-pdf.css
@@ -643,39 +643,96 @@ a {
     This shape should be modified after cookbook change*/
 /* stylelint-disable-next-line meowtec/no-px */
 /* stylelint-disable-next-line meowtec/no-px */
-[data-type=chapter] > h1[data-type=document-title] .os-number {
-  string-set: chapter-number content();
-}
-[data-type=chapter] > h1[data-type=document-title] .os-text {
-  string-set: chapter-title content();
-}
-
-[data-type=chapter] > [data-type=page].introduction .intro-text > h2[data-type=document-title] {
-  string-set: module-number string(chapter-number);
-}
-[data-type=chapter] > [data-type=page].introduction .intro-text > h2[data-type=document-title] .os-text {
-  string-set: module-title content();
-}
-[data-type=chapter] > [data-type=page]:not(.introduction) > h2[data-type=document-title] .os-number {
-  string-set: module-number content();
-}
-[data-type=chapter] > [data-type=page]:not(.introduction) > h2[data-type=document-title] .os-text {
-  string-set: module-title content();
+p.folio-chapter {
+  position: running(folio_chapter);
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
 }
 
-.os-eoc > h2[data-type=document-title] .os-text {
-  string-set: eoc-title content();
+p.folio-module {
+  position: running(folio_module);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
 }
 
-.appendix > h1[data-type=document-title] .os-number {
-  string-set: appendix-number content();
-}
-.appendix > h1[data-type=document-title] .os-text {
-  string-set: appendix-title content();
+p.folio-eoc-left {
+  position: running(folio_eoc_left);
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
 }
 
-div[data-type=composite-page].os-eob > h1[data-type=document-title] .os-text {
-  string-set: eob-title content();
+p.folio-eoc-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-eoc-right {
+  position: running(folio_eoc_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
+}
+
+p.folio-eoc-right::after {
+  content: "     " counter(page);
+}
+
+p.folio-appendix-left {
+  position: running(folio_appendix_left);
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
+}
+
+p.folio-appendix-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-appendix-right {
+  position: running(folio_appendix_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
+}
+
+p.folio-appendix-right::after {
+  content: "     " counter(page);
+}
+
+p.folio-eob-left {
+  position: running(folio_eob_left);
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
+}
+
+p.folio-eob-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-eob-right {
+  position: running(folio_eob_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Mulish", sans-serif;
+  color: #A5A5A5;
+  font-weight: 700;
+}
+
+p.folio-eob-right::after {
+  content: "     " counter(page);
 }
 
 nav#toc {
@@ -704,7 +761,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:first {
   @top-left-corner {
     content: none;
   }
@@ -741,159 +798,159 @@ div[data-type=composite-page].os-eob {
 
 @page :left {
   @top-left {
+    content: element(folio_chapter);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(chapter-number) " • " string(chapter-title);
   }
   @top-left-corner {
-    font-size: 0.8333333333rem;
-    font-family: "Mulish", sans-serif;
-    color: #A5A5A5;
-    font-weight: 700;
     content: counter(page);
     margin-right: 40px;
-  }
-  @bottom-left {
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
+  }
+  @bottom-left {
     content: string(access-for-free-msg);
+    font-size: 0.8333333333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
   }
 }
 @page :right {
   @top-right {
+    content: element(folio_module);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(module-number) " • " string(module-title);
   }
   @top-right-corner {
+    content: counter(page);
+    margin-left: 40px;
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: counter(page);
-    margin-left: 40px;
   }
 }
 @page preface:left {
   @top-left {
+    content: string(preface-msg);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(preface-msg);
   }
   @top-left-corner {
-    font-size: 0.8333333333rem;
-    font-family: "Mulish", sans-serif;
-    color: #A5A5A5;
-    font-weight: 700;
     content: counter(page);
     margin-right: 40px;
-  }
-  @bottom-left {
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
+  }
+  @bottom-left {
     content: string(access-for-free-msg);
+    font-size: 0.8333333333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
   }
 }
 @page preface:right {
   @top-right {
+    content: string(preface-msg);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(preface-msg);
   }
   @top-right-corner {
+    content: counter(page);
+    margin-left: 40px;
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: counter(page);
-    margin-left: 40px;
   }
 }
 @page eoc:left {
   @top-left {
+    content: element(folio_eoc_left);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: counter(page) "     " string(chapter-number) " • " string(eoc-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page eoc:right {
   @top-right {
+    content: element(folio_eoc_right);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(chapter-number) " • " string(eoc-title) "     " counter(page);
   }
 }
 @page appendix:left {
   @top-left {
+    content: element(folio_appendix_left);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: counter(page) "     " string(appendix-number) " • " string(appendix-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page appendix:right {
   @top-right {
+    content: element(folio_appendix_right);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(appendix-number) " • " string(appendix-title) "     " counter(page);
   }
 }
 @page eob:left {
   @top-left {
+    content: element(folio_eob_left);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: counter(page) "     " string(eob-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page eob:right {
   @top-right {
+    content: element(folio_eob_right);
     font-size: 0.8333333333rem;
     font-family: "Mulish", sans-serif;
     color: #A5A5A5;
     font-weight: 700;
-    content: string(eob-title) "     " counter(page);
   }
 }
 @page {


### PR DESCRIPTION
Issue: https://github.com/openstax/cnx-recipes/issues/5113

Previously we were using `string-set()` and `content()` css properties to copy text of titles and put them in the folio. But it copied only text, not html structure (e.g `<sub>`, `<i>` etc.). There is no property for doing that. But there are properties `running()` and `element()` that can cut html fragment and paste it where we want (check here: https://www.w3.org/TR/css-gcpm-3/#running-syntax). To use them I had to create additional paragraphs that can be cut from the content. Here is a work for that: https://github.com/openstax/cookbook/pull/228/