### PR TITLE
5212 ochem caption smallcaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `smallcaps in captions` in `webview`
 * Fix alignment in `multipart-questions` from `webview`
 
 ## [v1.133.0] - 2023-08-10

--- a/styles/designs/webview/basic-styles.scss
+++ b/styles/designs/webview/basic-styles.scss
@@ -78,3 +78,8 @@ u[data-effect="double-underline"] {
 .smallcaps {
   font-size: scaled_size(1.3rem);
 }
+
+//Smallcaps in caption
+.os-caption span.smallcaps{
+  font-size: scaled_size(1rem);
+}

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -1,6 +1,5 @@
 @import url("./downloaded-fonts/IBM-Plex-Sans.css");
 @import url("./downloaded-fonts/IBM-Plex-Mono.css");
-
 :root {
   --content-text-scale: 1;
 }
@@ -74,6 +73,10 @@ u[data-effect=double-underline] {
 
 .smallcaps {
   font-size: calc(1.3rem * var(--content-text-scale));
+}
+
+.os-caption span.smallcaps {
+  font-size: calc(1rem * var(--content-text-scale));
 }
 
 h1 {


### PR DESCRIPTION
**Issue**: [5212](https://github.com/openstax/cnx-recipes/issues/5212)

The `.smallcaps `class was properly applied. However, the `font-size `in the `.smallcaps `class (1.3rem) was larger than the `font-size` of the overall caption text(`1.2rem`). To remedy this, a separate css rule was created to target the `.smallcaps ` class within a caption and reduced the `font-size `to `1.1rem` so that `.smallcaps `are visually present in captions _(see before and after screenshots)._

**Before:**_(smallcaps not reflected in caption due to the closeness of the font-sizes)_
![Screenshot 2023-08-17 at 3 27 21 PM](https://github.com/openstax/ce-styles/assets/26155528/48bd7e6f-b9bd-4b77-8f4e-68bec28e206c)

**After:** _(small caps are now reflected in the caption with no change to the smallcaps that exist within the body of the book)_
![Screenshot 2023-08-17 at 4 53 28 PM](https://github.com/openstax/ce-styles/assets/26155528/52719854-8fa4-487b-a6ee-3192764b126e)

**For QA Testing:**
- smallcaps content within a caption should appear smaller(`font-size: 1.1rem`) than the overall caption text (`font-size 1.2 rem`)
- smallcaps that exist within the body of the book should remain the same(`font-size: 1.3rem`)

