### PR TITLE
Update team name in README to CE Design Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ Workarounds:
 # Important Links
  - [Content Engineering Team Confluence Documentation](https://openstax.atlassian.net/wiki/spaces/CE/overview)
  - [How to Release CE Styles](https://openstax.atlassian.net/l/c/TjrhH68R)
- - [CE Styles Project Board]([https://app.zenhub.com/workspaces/ce-styles-5cdc84baee941c07853fbbf2/board?repos=49744755,11369724,137909279,63083783](https://github.com/orgs/openstax/projects/40/))
+ - [CE Design Systems Project Board](https://github.com/orgs/openstax/projects/40/)
  - [Cookbook Repo](https://github.com/openstax/cookbook)


### PR DESCRIPTION
- Update team name to be CE Design Systems
- Fixed the malformed link to the board