### PR TITLE
better handling for dart pub get error using onCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
       "dockerfile": "../Dockerfile",
       "context": "..",
     },
-    "onCreateCommand": "if [ ! -d node_modules ]; then yarn install; fi",
+    "onCreateCommand": "bash ./.devcontainer/onCreateCommand.sh",
     "workspaceMount": "source=${localWorkspaceFolder},target=/code,type=bind,consistency=default",
     "workspaceFolder": "/code",
     "settings": {

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -d node_modules ]; then
+  echo "Installing node dependencies ..."
+  yarn install
+fi
+
+echo "Installing dart dependencies ..."
+dart pub get
+
+## It's common to get a network error when trying to install dart deps.
+if [[ $? == 69 ]]; then
+  echo "ATTENTION!!! Dart dependencies have failed to install due to a network error."
+  echo "To troubleshoot, re-run 'dart pub get' in the terminal until it succeeds."
+  echo "If command continues to fail, try switching to a VPN."
+fi
+
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Move `dart pub get` to `onCreateCommand` in devcontainer
 * Restore `pubspec.lock` & change order of `dart pub get` in Dockerfile
 * Fix problem with tables from `nursing-external`
 * Create basic files and style `TOC` in `data-science`

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,3 @@ ENV SKIP_MY_POSTINSTALL=true
 
 # Install code
 COPY . ./
-
-RUN dart pub get


### PR DESCRIPTION
Documentation for onCreateCommand https://containers.dev/implementors/json_reference/#lifecycle-scripts

If the `dart pub get` install fails due to our friend the network error, this is what it looks like now:

<img width="900" alt="Screenshot 2023-12-08 at 10 32 03 AM" src="https://github.com/openstax/ce-styles/assets/26280712/fe9c36f7-9930-406c-81a5-cb88e5523174">

The container will build whether this command succeeds or fails. 