### PR TITLE
fix ./script/run using superset docker config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `./script/run`
 * Move `dart pub get` to `onCreateCommand` in devcontainer
 * Restore `pubspec.lock` & change order of `dart pub get` in Dockerfile
 * Fix problem with tables from `nursing-external`

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,0 +1,8 @@
+## Used in ./script/run
+## Assumes styles-base has been tagged & uses this repo's Dockerfile
+
+FROM styles-base
+WORKDIR /code
+COPY . ./
+
+RUN dart pub get

--- a/script/run
+++ b/script/run
@@ -11,8 +11,9 @@ do
   shift
 done
 
-docker build -t ce-styles-image .
-docker run -d -t --rm --mount type=bind,source="$PWD",target=/code --name styles_temp_container ce-styles-image /bin/bash
+docker build -f Dockerfile -t styles-base .
+docker build -f Dockerfile.run -t styles-full .
+docker run -d -t --rm --mount type=bind,source="$PWD",target=/code --name styles_temp_container styles-full /bin/bash
 echo "Executing $@..."
 docker exec "${env_vars[@]}" styles_temp_container "$@"
 docker stop styles_temp_container > /dev/null    # mutes "styles_temp_container" output


### PR DESCRIPTION
should fix `./script/run` (broken by #397) by creating `Dockerfile.run` that supersets the dockerfile used for the devcontainer

