### PR TITLE
Restrict width of images in figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Style `TOC` in `information-systems`
 * Create `ItalicTextShape` in `common` files
 * Initialize `information-systems`
+* Fix css issue with `img` inside `figure`
 
 ## [v1.142.0] - 2023-12-15
 

--- a/styles/designs/webview/parts/_figureimage-components.scss
+++ b/styles/designs/webview/parts/_figureimage-components.scss
@@ -25,7 +25,7 @@ $Image--InFigure: (
   _name: "ImageInFigure",
   _subselector: ' img',
   _properties: (
-    max-width: 100%,
+    width: 100%,
     margin: 0,
   )
 );

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -202,7 +202,7 @@ figure > .media {
 }
 
 figure img {
-  max-width: 100%;
+  width: 100%;
   margin: 0;
 }
 


### PR DESCRIPTION
max-width does not work; setting width to 100% does. This parallels a change in Rex.
https://github.com/openstax/rex-web/pull/2104