### PR TITLE
style highlight.js line numbers in pdf and webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Style `highlight.js line numbers` in `python webview and pdf`
 * Fix `splash image` in `corn`
+* Enable `highlight.js styles` in `webview`
 * Increase `carnival` `AnswerKeys` number spacing
 * Fix problem with table border in `carnival`
 * Style `eob` in `information-systems`
 
 ## [v1.143.0] - 2024-01-12
 
-* Enable `highlight.js styles` in `webview`
 * Style `eoc` in `information-systems`
 * Style `notes` in `information-systems`
 * Style `lists` in `information-systems`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Style `highlight.js line numbers` in `python webview and pdf`
 * Fix `splash image` in `corn`
 * Enable `highlight.js styles` in `webview`
 * Increase `carnival` `AnswerKeys` number spacing
@@ -14,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.143.0] - 2024-01-12
 
+* Enable `highlight.js styles` in `webview`
 * Style `eoc` in `information-systems`
 * Style `notes` in `information-systems`
 * Style `lists` in `information-systems`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Style `highlight.js line numbers` in `python webview and pdf`
 * Fix `splash image` in `corn`
-* Enable `highlight.js styles` in `webview`
 * Increase `carnival` `AnswerKeys` number spacing
 * Fix problem with table border in `carnival`
 * Style `eob` in `information-systems`

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -215,21 +215,6 @@
     ),
 ));
 
-//Style Line Numbers
-@include add_settings((
-  CodeSnippetLineNumbers:(
-    _selectors:('.hljs-ln-numbers'),
-    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
-    'CodeSnippetLineNumbers:::border-right': 1pt solid,
-    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
-  ),
-  CodeSnippetLineNumbersCode:(
-    _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
-
-  ),
-));
-
 //Functions
 @include add_settings((
     Function: (

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -434,7 +434,7 @@
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
 @include use('CodeSnippetLineNumbers', 'webview:::CodeSnippetLineNumbersShape');
-@include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersCodeShape');
+@include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersShape');
 
 // Functions
 @include use('Function', 'webview:::FunctionShape');

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -433,8 +433,8 @@
 @include use('CodeString', 'common:::ColoredText');
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
-@include use('CodeSnippetLineNumbers', 'webview:::CodeSnippetLineNumbersShape');
-@include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersShape');
+@include use('CodeSnippet', 'webview:::CodeSnippetLineNumbersShape');
+// @include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersShape');
 
 // Functions
 @include use('Function', 'webview:::FunctionShape');

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -220,26 +220,13 @@
   CodeSnippetLineNumbers:(
     _selectors:('.hljs-ln-numbers'),
     'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
-    // 'CodeSnippetLineNumbers:::padding-top': 0px !important,
-    // 'CodeSnippetLineNumbers:::padding-bottom': 0px !important,
-    // 'CodeSnippetLineNumbers:::padding-left': 0px !important,
-    // 'CodeSnippetLineNumbers:::border-top': none !important,
-    'CodeSnippetLineNumbers:::border-right': 1pt solid #000000 !important,
-    // 'CodeSnippetLineNumbers:::border-bottom': none !important,
-    // 'CodeSnippetLineNumbers:::border-left': none !important,
+    'CodeSnippetLineNumbers:::border-right': 1pt solid,
+    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),
     'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
-    'CodeSnippetLineNumbersCode:::padding-left': 5px,
-    // 'CodeSnippetLineNumbersCode:::border-top': none !important,
-    // 'CodeSnippetLineNumbersCode:::border-right': none !important,
-    // 'CodeSnippetLineNumbersCode:::border-bottom': none !important,
-    'CodeSnippetLineNumbersCode:::border-left':solid 1pt #000000 !important,
-    // 'CodeSnippetLineNumbersCode:::border-style':none !important,
-    // 'CodeSnippetLineNumbersCode:::padding-top': 0px !important,
-    // 'CodeSnippetLineNumbersCode:::padding-right': 0px !important,
-    // 'CodeSnippetLineNumbersCode:::padding-bottom': 0px !important,
+
   ),
 ));
 

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -215,6 +215,34 @@
     ),
 ));
 
+//Style Line Numbers
+@include add_settings((
+  CodeSnippetLineNumbers:(
+    _selectors:('.hljs-ln-numbers'),
+    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
+    'CodeSnippetLineNumbers:::padding-top': 0px !important,
+    'CodeSnippetLineNumbers:::padding-bottom': 0px !important,
+    'CodeSnippetLineNumbers:::padding-left': 0px !important,
+    'CodeSnippetLineNumbers:::border-top': none !important,
+    'CodeSnippetLineNumbers:::border-right': 1pt solid #000000 !important,
+    'CodeSnippetLineNumbers:::border-bottom': none !important,
+    'CodeSnippetLineNumbers:::border-left': none !important,
+  ),
+  CodeSnippetLineNumbersCode:(
+    _selectors:('.hljs-ln-code'),
+    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
+    'CodeSnippetLineNumbersCode:::padding-left': 5px,
+    'CodeSnippetLineNumbersCode:::border-top': none !important,
+    'CodeSnippetLineNumbersCode:::border-right': none !important,
+    'CodeSnippetLineNumbersCode:::border-bottom': none !important,
+    'CodeSnippetLineNumbersCode:::border-left':solid 1pt #000000 !important,
+    'CodeSnippetLineNumbersCode:::border-style':none !important,
+    'CodeSnippetLineNumbersCode:::padding-top': 0px !important,
+    'CodeSnippetLineNumbersCode:::padding-right': 0px !important,
+    'CodeSnippetLineNumbersCode:::padding-bottom': 0px !important,
+  ),
+));
+
 //Functions
 @include add_settings((
     Function: (
@@ -433,6 +461,8 @@
 @include use('CodeString', 'common:::ColoredText');
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
+@include use('CodeSnippetLineNumbers', 'common:::CodeSnippetLineNumbersShape');
+@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersCodeShape');
 
 // Functions
 @include use('Function', 'webview:::FunctionShape');

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -220,26 +220,26 @@
   CodeSnippetLineNumbers:(
     _selectors:('.hljs-ln-numbers'),
     'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
-    'CodeSnippetLineNumbers:::padding-top': 0px !important,
-    'CodeSnippetLineNumbers:::padding-bottom': 0px !important,
-    'CodeSnippetLineNumbers:::padding-left': 0px !important,
-    'CodeSnippetLineNumbers:::border-top': none !important,
+    // 'CodeSnippetLineNumbers:::padding-top': 0px !important,
+    // 'CodeSnippetLineNumbers:::padding-bottom': 0px !important,
+    // 'CodeSnippetLineNumbers:::padding-left': 0px !important,
+    // 'CodeSnippetLineNumbers:::border-top': none !important,
     'CodeSnippetLineNumbers:::border-right': 1pt solid #000000 !important,
-    'CodeSnippetLineNumbers:::border-bottom': none !important,
-    'CodeSnippetLineNumbers:::border-left': none !important,
+    // 'CodeSnippetLineNumbers:::border-bottom': none !important,
+    // 'CodeSnippetLineNumbers:::border-left': none !important,
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),
     'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
     'CodeSnippetLineNumbersCode:::padding-left': 5px,
-    'CodeSnippetLineNumbersCode:::border-top': none !important,
-    'CodeSnippetLineNumbersCode:::border-right': none !important,
-    'CodeSnippetLineNumbersCode:::border-bottom': none !important,
+    // 'CodeSnippetLineNumbersCode:::border-top': none !important,
+    // 'CodeSnippetLineNumbersCode:::border-right': none !important,
+    // 'CodeSnippetLineNumbersCode:::border-bottom': none !important,
     'CodeSnippetLineNumbersCode:::border-left':solid 1pt #000000 !important,
-    'CodeSnippetLineNumbersCode:::border-style':none !important,
-    'CodeSnippetLineNumbersCode:::padding-top': 0px !important,
-    'CodeSnippetLineNumbersCode:::padding-right': 0px !important,
-    'CodeSnippetLineNumbersCode:::padding-bottom': 0px !important,
+    // 'CodeSnippetLineNumbersCode:::border-style':none !important,
+    // 'CodeSnippetLineNumbersCode:::padding-top': 0px !important,
+    // 'CodeSnippetLineNumbersCode:::padding-right': 0px !important,
+    // 'CodeSnippetLineNumbersCode:::padding-bottom': 0px !important,
   ),
 ));
 
@@ -461,8 +461,8 @@
 @include use('CodeString', 'common:::ColoredText');
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
-@include use('CodeSnippetLineNumbers', 'common:::CodeSnippetLineNumbersShape');
-@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersCodeShape');
+@include use('CodeSnippetLineNumbers', 'webview:::CodeSnippetLineNumbersShape');
+@include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersCodeShape');
 
 // Functions
 @include use('Function', 'webview:::FunctionShape');

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -434,7 +434,6 @@
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
 @include use('CodeSnippet', 'webview:::CodeSnippetLineNumbersShape');
-// @include use('CodeSnippetLineNumbersCode', 'webview:::CodeSnippetLineNumbersShape');
 
 // Functions
 @include use('Function', 'webview:::FunctionShape');

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -182,7 +182,7 @@ $bandColor: #24739E;
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
 @include use('CodeSnippetLineNumbers', 'common:::CodeSnippetLineNumbersShape');
-@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersCodeShape');
+@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersShape');
 
 
 //Eob

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -181,8 +181,7 @@ $bandColor: #24739E;
 @include use('CodeString', 'common:::ColoredText');
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
-@include use('CodeSnippetLineNumbers', 'common:::CodeSnippetLineNumbersShape');
-@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersShape');
+@include use('CodeSnippet', 'common:::CodeSnippetLineNumbersShape');
 
 
 //Eob

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -141,6 +141,7 @@ $bandColor: #24739E;
     _selectors:('.hljs-ln-numbers'),
     'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
     'CodeSnippetLineNumbers:::border-right': solid 1pt #000000,
+    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -135,20 +135,6 @@ $bandColor: #24739E;
     ),
 ));
 
-//Style Line Numbers
-@include add_settings((
-  CodeSnippetLineNumbers:(
-    _selectors:('.hljs-ln-numbers'),
-    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
-    'CodeSnippetLineNumbers:::border-right': solid 1pt #000000,
-    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
-  ),
-  CodeSnippetLineNumbersCode:(
-    _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont")
-  ),
-));
-
 @include use('BookRoot', "common:::BookRoot");
 @include use('Toc', 'cardboard:::NoUnitToc');
 @include use('LearningObjectives', 'cardboard:::LearningObjectivesShape');

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -135,6 +135,19 @@ $bandColor: #24739E;
     ),
 ));
 
+//Style Line Numbers
+@include add_settings((
+  CodeSnippetLineNumbers:(
+    _selectors:('.hljs-ln-numbers'),
+    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
+    'CodeSnippetLineNumbers:::border-right': solid 1pt #000000,
+  ),
+  CodeSnippetLineNumbersCode:(
+    _selectors:('.hljs-ln-code'),
+    'CodeSnippetLineNumbersCode:::padding-left': 5px
+  ),
+));
+
 @include use('BookRoot', "common:::BookRoot");
 @include use('Toc', 'cardboard:::NoUnitToc');
 @include use('LearningObjectives', 'cardboard:::LearningObjectivesShape');
@@ -181,6 +194,9 @@ $bandColor: #24739E;
 @include use('CodeString', 'common:::ColoredText');
 @include use('CodeBuildIn', 'common:::ColoredText');
 @include use('CodeNumber', 'common:::ColoredText');
+@include use('CodeSnippetLineNumbers', 'common:::CodeSnippetLineNumbersShape');
+@include use('CodeSnippetLineNumbersCode', 'common:::CodeSnippetLineNumbersCodeShape');
+
 
 //Eob
 @include use('AnswerKey', 'cardboard:::AnswerKeyShape');

--- a/styles/books/python/book.scss
+++ b/styles/books/python/book.scss
@@ -144,7 +144,7 @@ $bandColor: #24739E;
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::padding-left': 5px
+    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont")
   ),
 ));
 

--- a/styles/design-settings/cardboard/_settings.scss
+++ b/styles/design-settings/cardboard/_settings.scss
@@ -18,6 +18,7 @@
 @import 'design-settings/cardboard/parts/references-settings.scss';
 @import 'design-settings/cardboard/parts/example-settings';
 @import 'design-settings/cardboard/parts/appendixglossary-settings';
+@import 'design-settings/cardboard/parts/codesnippet-settings';
 @import 'design-settings/cosmos/parts/unit-settings';
 @import 'design-settings/cardboard/parts/module-settings';
 @import 'design-settings/cardboard/parts/keyterms-settings';

--- a/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
@@ -3,11 +3,14 @@
   CodeSnippetLineNumbers:(
     _selectors:('.hljs-ln-numbers'),
     'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
-    'CodeSnippetLineNumbers:::border-right': solid 1pt #000000,
+    'CodeSnippetLineNumbers:::border-right': 1pt solid,
     'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
+    'CodeSnippetLineNumbers:::text-align': right,
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont")
+    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont"),
+    'CodeSnippetLineNumbersCode:::text-align': left,
+
   ),
 ));

--- a/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
@@ -1,0 +1,13 @@
+//Style Line Numbers
+@include add_settings((
+  CodeSnippetLineNumbers:(
+    _selectors:('.hljs-ln-numbers'),
+    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
+    'CodeSnippetLineNumbers:::border-right': solid 1pt #000000,
+    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
+  ),
+  CodeSnippetLineNumbersCode:(
+    _selectors:('.hljs-ln-code'),
+    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont")
+  ),
+));

--- a/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/cardboard/parts/_codesnippet-settings.scss
@@ -1,16 +1,15 @@
-//Style Line Numbers
 @include add_settings((
-  CodeSnippetLineNumbers:(
-    _selectors:('.hljs-ln-numbers'),
-    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::monospaceFont"),
-    'CodeSnippetLineNumbers:::border-right': 1pt solid,
-    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
-    'CodeSnippetLineNumbers:::text-align': right,
-  ),
-  CodeSnippetLineNumbersCode:(
-    _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::monospaceFont"),
-    'CodeSnippetLineNumbersCode:::text-align': left,
-
-  ),
+ CodeSnippet:(
+    _selectors: ('.hljs-ln'),
+      CodeSnippetLineNumbers: (
+        font-family: (_ref:"typography:::monospaceFont"),
+        border-right: 1pt solid,
+        border-color: (_ref: 'colorMap:::codePythonParamsColor'),
+        text-align: right,
+      ),
+      CodeSnippetLineNumbersCode: (
+        font-family: (_ref:"typography:::monospaceFont"),
+        text-align: left,
+      ),
+ )
 ));

--- a/styles/design-settings/webview/_settings.scss
+++ b/styles/design-settings/webview/_settings.scss
@@ -4,3 +4,4 @@
 
 //template parts
 @import 'design-settings/webview/parts/teacher-settings';
+@import 'design-settings/webview/parts/codesnippet-settings';

--- a/styles/design-settings/webview/_typography.scss
+++ b/styles/design-settings/webview/_typography.scss
@@ -5,5 +5,6 @@
     typography: (
         fontOption1: ('"IBM Plex Serif"', Helvetica, Arial, sans-serif),
         fontOption2: ('"IBM Plex Mono"', monospace),
+        fontOption3: ('Courier Prime', monospace),
     )
 ));

--- a/styles/design-settings/webview/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/webview/parts/_codesnippet-settings.scss
@@ -1,16 +1,15 @@
-//Style Line Numbers
 @include add_settings((
-  CodeSnippetLineNumbers:(
-    _selectors:('.hljs-ln-numbers'),
-    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
-    'CodeSnippetLineNumbers:::border-right': 1pt solid,
-    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
-    'CodeSnippetLineNumbers:::text-align': right,
-  ),
-  CodeSnippetLineNumbersCode:(
-    _selectors:('.hljs-ln-code'),
-    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
-    'CodeSnippetLineNumbersCode:::text-align': left,
-
-  ),
+ CodeSnippet:(
+    _selectors: ('.hljs-ln'),
+      CodeSnippetLineNumbers: (
+        font-family: (_ref:"typography:::fontOption3"),
+        border-right: 1pt solid,
+        border-color: (_ref: 'colorMap:::codePythonParamsColor'),
+        text-align: right,
+      ),
+      CodeSnippetLineNumbersCode: (
+        font-family: (_ref:"typography:::fontOption3"),
+        text-align: left,
+      ),
+ )
 ));

--- a/styles/design-settings/webview/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/webview/parts/_codesnippet-settings.scss
@@ -5,10 +5,12 @@
     'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
     'CodeSnippetLineNumbers:::border-right': 1pt solid,
     'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
+    'CodeSnippetLineNumbers:::text-align': right,
   ),
   CodeSnippetLineNumbersCode:(
     _selectors:('.hljs-ln-code'),
     'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
+    'CodeSnippetLineNumbersCode:::text-align': left,
 
   ),
 ));

--- a/styles/design-settings/webview/parts/_codesnippet-settings.scss
+++ b/styles/design-settings/webview/parts/_codesnippet-settings.scss
@@ -1,0 +1,14 @@
+//Style Line Numbers
+@include add_settings((
+  CodeSnippetLineNumbers:(
+    _selectors:('.hljs-ln-numbers'),
+    'CodeSnippetLineNumbers:::font-family': (_ref:"typography:::fontOption3"),
+    'CodeSnippetLineNumbers:::border-right': 1pt solid,
+    'CodeSnippetLineNumbers:::border-color': (_ref: 'colorMap:::codePythonParamsColor'),
+  ),
+  CodeSnippetLineNumbersCode:(
+    _selectors:('.hljs-ln-code'),
+    'CodeSnippetLineNumbersCode:::font-family': (_ref:"typography:::fontOption3"),
+
+  ),
+));

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -88,8 +88,8 @@ $CodeSnippet__LineNumbers: (
       border-right: enum('ValueSet:::OPTIONAL'),
       border-color: enum('ValueSet:::OPTIONAL'),
       padding-right: 10px,
-      text-align: right,
-      vertical-align: top,
+      text-align: enum('ValueSet:::OPTIONAL'),
+      vertical-align: top
     )
 );
 
@@ -99,6 +99,7 @@ $CodeSnippet__LineNumbers--Code: (
     _properties: (
       font-size: font-scale(1),
       font-family: enum('ValueSet:::OPTIONAL'),
-      padding-left: 0.5rem
+      padding-left: 0.5rem,
+      text-align: enum('ValueSet:::OPTIONAL'),
     )
 );

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -79,27 +79,29 @@ $VisuallyHidden: (
 );
 
 //Styles specifically for code snippet tables
+$CodeSnippet__Container: empty_wrapper(CodeSnippet, '');
+
 $CodeSnippet__LineNumbers: (
     _name: 'CodeSnippetLineNumbers',
-    _subselector: '',
+    _subselector: ' .hljs-ln-numbers',
     _properties: (
-      font-size: font-scale(1),
-      font-family: enum('ValueSet:::OPTIONAL'),
-      border-right: enum('ValueSet:::OPTIONAL'),
-      border-color: enum('ValueSet:::OPTIONAL'),
+      font-size: 1.2rem,
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-right: enum('ValueSet:::REQUIRED'),
+      border-color: enum('ValueSet:::REQUIRED'),
       padding-right: 10px,
-      text-align: enum('ValueSet:::OPTIONAL'),
+      text-align: enum('ValueSet:::REQUIRED'),
       vertical-align: top
     )
 );
 
 $CodeSnippet__LineNumbers--Code: (
     _name: 'CodeSnippetLineNumbersCode',
-    _subselector: '',
+    _subselector: ' .hljs-ln-code',
     _properties: (
-      font-size: font-scale(1),
-      font-family: enum('ValueSet:::OPTIONAL'),
+      font-size: 1.2rem,
+      font-family: enum('ValueSet:::REQUIRED'),
       padding-left: 0.5rem,
-      text-align: enum('ValueSet:::OPTIONAL'),
+      text-align: enum('ValueSet:::REQUIRED'),
     )
 );

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -86,16 +86,9 @@ $CodeSnippetLineNumbers: (
       font-size: font-scale(1),
       font-family: enum('ValueSet:::REQUIRED'),
       border-right: enum('ValueSet:::REQUIRED'),
-      padding-top: enum('ValueSet:::OPTIONAL'),
       padding-right: 10px,
-      padding-bottom: enum('ValueSet:::OPTIONAL'),
-      padding-left: enum('ValueSet:::OPTIONAL'),
       text-align: right,
       vertical-align: top,
-      border-top: enum('ValueSet:::OPTIONAL'),
-      border-bottom: enum('ValueSet:::OPTIONAL'),
-      border-left: enum('ValueSet:::OPTIONAL'),
-      border-style: enum('ValueSet:::OPTIONAL')
     )
 );
 
@@ -105,14 +98,6 @@ $CodeSnippetLineNumbersCode: (
     _properties: (
       font-size: font-scale(1),
       font-family: enum('ValueSet:::REQUIRED'),
-      border-top: enum('ValueSet:::OPTIONAL'),
-      border-right: enum('ValueSet:::OPTIONAL'),
-      border-bottom: enum('ValueSet:::OPTIONAL'),
-      border-left: enum('ValueSet:::OPTIONAL'),
-      border-style: enum('ValueSet:::OPTIONAL'),
-      padding-top: enum('ValueSet:::OPTIONAL'),
-      padding-right: enum('ValueSet:::OPTIONAL'),
-      padding-bottom: enum('ValueSet:::OPTIONAL'),
       padding-left: 0.5rem !important
     )
 );

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -84,9 +84,9 @@ $CodeSnippet__LineNumbers: (
     _subselector: '',
     _properties: (
       font-size: font-scale(1),
-      font-family: enum('ValueSet:::REQUIRED'),
-      border-right: enum('ValueSet:::REQUIRED'),
-      border-color: enum('ValueSet:::REQUIRED'),
+      font-family: enum('ValueSet:::OPTIONAL'),
+      border-right: enum('ValueSet:::OPTIONAL'),
+      border-color: enum('ValueSet:::OPTIONAL'),
       padding-right: 10px,
       text-align: right,
       vertical-align: top,
@@ -98,7 +98,7 @@ $CodeSnippet__LineNumbers--Code: (
     _subselector: '',
     _properties: (
       font-size: font-scale(1),
-      font-family: enum('ValueSet:::REQUIRED'),
+      font-family: enum('ValueSet:::OPTIONAL'),
       padding-left: 0.5rem
     )
 );

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -79,25 +79,26 @@ $VisuallyHidden: (
 );
 
 //Styles specifically for code snippet tables
-$CodeSnippetLineNumbers: (
+$CodeSnippet__LineNumbers: (
     _name: 'CodeSnippetLineNumbers',
     _subselector: '',
     _properties: (
       font-size: font-scale(1),
       font-family: enum('ValueSet:::REQUIRED'),
       border-right: enum('ValueSet:::REQUIRED'),
+      border-color: enum('ValueSet:::REQUIRED'),
       padding-right: 10px,
       text-align: right,
       vertical-align: top,
     )
 );
 
-$CodeSnippetLineNumbersCode: (
+$CodeSnippet__LineNumbers--Code: (
     _name: 'CodeSnippetLineNumbersCode',
     _subselector: '',
     _properties: (
       font-size: font-scale(1),
       font-family: enum('ValueSet:::REQUIRED'),
-      padding-left: 0.5rem !important
+      padding-left: 0.5rem
     )
 );

--- a/styles/designs/common/pdf/_common-components.scss
+++ b/styles/designs/common/pdf/_common-components.scss
@@ -78,3 +78,41 @@ $VisuallyHidden: (
     )
 );
 
+//Styles specifically for code snippet tables
+$CodeSnippetLineNumbers: (
+    _name: 'CodeSnippetLineNumbers',
+    _subselector: '',
+    _properties: (
+      font-size: font-scale(1),
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-right: enum('ValueSet:::REQUIRED'),
+      padding-top: enum('ValueSet:::OPTIONAL'),
+      padding-right: 10px,
+      padding-bottom: enum('ValueSet:::OPTIONAL'),
+      padding-left: enum('ValueSet:::OPTIONAL'),
+      text-align: right,
+      vertical-align: top,
+      border-top: enum('ValueSet:::OPTIONAL'),
+      border-bottom: enum('ValueSet:::OPTIONAL'),
+      border-left: enum('ValueSet:::OPTIONAL'),
+      border-style: enum('ValueSet:::OPTIONAL')
+    )
+);
+
+$CodeSnippetLineNumbersCode: (
+    _name: 'CodeSnippetLineNumbersCode',
+    _subselector: '',
+    _properties: (
+      font-size: font-scale(1),
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-top: enum('ValueSet:::OPTIONAL'),
+      border-right: enum('ValueSet:::OPTIONAL'),
+      border-bottom: enum('ValueSet:::OPTIONAL'),
+      border-left: enum('ValueSet:::OPTIONAL'),
+      border-style: enum('ValueSet:::OPTIONAL'),
+      padding-top: enum('ValueSet:::OPTIONAL'),
+      padding-right: enum('ValueSet:::OPTIONAL'),
+      padding-bottom: enum('ValueSet:::OPTIONAL'),
+      padding-left: 0.5rem !important
+    )
+);

--- a/styles/designs/common/pdf/_common-shapes.scss
+++ b/styles/designs/common/pdf/_common-shapes.scss
@@ -59,7 +59,10 @@
 
 @include create_shape('common:::CodeSnippetLineNumbersShape', (
   _components: (
-    $CodeSnippet__LineNumbers,
-    $CodeSnippet__LineNumbers--Code,
-  ),
-));
+        map-merge($CodeSnippet__Container, (
+            _components: (
+              $CodeSnippet__LineNumbers--Code,
+              $CodeSnippet__LineNumbers,
+        )),
+    )),
+  ));

--- a/styles/designs/common/pdf/_common-shapes.scss
+++ b/styles/designs/common/pdf/_common-shapes.scss
@@ -60,11 +60,6 @@
 @include create_shape('common:::CodeSnippetLineNumbersShape', (
   _components: (
     $CodeSnippet__LineNumbers,
-  ),
-));
-
-@include create_shape('common:::CodeSnippetLineNumbersCodeShape', (
-  _components: (
     $CodeSnippet__LineNumbers--Code,
   ),
 ));

--- a/styles/designs/common/pdf/_common-shapes.scss
+++ b/styles/designs/common/pdf/_common-shapes.scss
@@ -57,3 +57,14 @@
   ),
 ));
 
+@include create_shape('common:::CodeSnippetLineNumbersShape', (
+  _components: (
+    $CodeSnippetLineNumbers,
+  ),
+));
+
+@include create_shape('common:::CodeSnippetLineNumbersCodeShape', (
+  _components: (
+    $CodeSnippetLineNumbersCode,
+  ),
+));

--- a/styles/designs/common/pdf/_common-shapes.scss
+++ b/styles/designs/common/pdf/_common-shapes.scss
@@ -59,12 +59,12 @@
 
 @include create_shape('common:::CodeSnippetLineNumbersShape', (
   _components: (
-    $CodeSnippetLineNumbers,
+    $CodeSnippet__LineNumbers,
   ),
 ));
 
 @include create_shape('common:::CodeSnippetLineNumbersCodeShape', (
   _components: (
-    $CodeSnippetLineNumbersCode,
+    $CodeSnippet__LineNumbers--Code,
   ),
 ));

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -52,7 +52,7 @@ $CodeSnippet__LineNumbers: (
       border-right: enum('ValueSet:::OPTIONAL'),
       border-color: enum('ValueSet:::OPTIONAL'),
       padding-right: 10px,
-      text-align: right,
+      text-align: enum('ValueSet:::OPTIONAL'),
       vertical-align: top
     )
 );
@@ -63,6 +63,7 @@ $CodeSnippet__LineNumbers--Code: (
     _properties: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::OPTIONAL'),
-      padding-left: 0.5rem
+      padding-left: 0.5rem,
+      text-align: enum('ValueSet:::OPTIONAL'),
     )
 );

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -50,7 +50,7 @@ $CodeSnippet__LineNumbers: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::REQUIRED'),
       border-right: enum('ValueSet:::REQUIRED'),
-      border-color: emum('ValueSet:::REQUIRED'),
+      border-color: enum('ValueSet:::REQUIRED'),
       padding-right: 10px,
       text-align: right,
       vertical-align: top

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -63,7 +63,6 @@ $CodeSnippet__LineNumbers--Code: (
     _properties: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::OPTIONAL'),
-      padding-left: 0.5rem,
-      text-align:left
+      padding-left: 0.5rem
     )
 );

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -63,6 +63,7 @@ $CodeSnippet__LineNumbers--Code: (
     _properties: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::OPTIONAL'),
-      padding-left: 0.5rem
+      padding-left: 0.5rem,
+      text-align:left
     )
 );

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -41,3 +41,42 @@ $CodeBlock--Centered: (
     margin: 0 auto,
   )
 );
+
+//Styles specifically for code snippet tables
+$CodeSnippetLineNumbers: (
+    _name: 'CodeSnippetLineNumbers',
+    _subselector: '',
+    _properties: (
+      font-size: font-scale(1),
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-right: enum('ValueSet:::REQUIRED'),
+      padding-top: enum('ValueSet:::OPTIONAL'),
+      padding-right: 10px,
+      padding-bottom: enum('ValueSet:::OPTIONAL'),
+      padding-left: enum('ValueSet:::OPTIONAL'),
+      text-align: right,
+      vertical-align: top,
+      border-top: enum('ValueSet:::OPTIONAL'),
+      border-bottom: enum('ValueSet:::OPTIONAL'),
+      border-left: enum('ValueSet:::OPTIONAL'),
+      border-style: enum('ValueSet:::OPTIONAL')
+    )
+);
+
+$CodeSnippetLineNumbersCode: (
+    _name: 'CodeSnippetLineNumbersCode',
+    _subselector: '',
+    _properties: (
+      font-size: font-scale(1),
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-top: enum('ValueSet:::OPTIONAL'),
+      border-right: enum('ValueSet:::OPTIONAL'),
+      border-bottom: enum('ValueSet:::OPTIONAL'),
+      border-left: enum('ValueSet:::OPTIONAL'),
+      border-style: enum('ValueSet:::OPTIONAL'),
+      padding-top: enum('ValueSet:::OPTIONAL'),
+      padding-right: enum('ValueSet:::OPTIONAL'),
+      padding-bottom: enum('ValueSet:::OPTIONAL'),
+      padding-left: 0.5rem !important
+    )
+);

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -48,9 +48,9 @@ $CodeSnippet__LineNumbers: (
     _subselector: '',
     _properties: (
       font-size: 1.2rem,
-      font-family: enum('ValueSet:::REQUIRED'),
-      border-right: enum('ValueSet:::REQUIRED'),
-      border-color: enum('ValueSet:::REQUIRED'),
+      font-family: enum('ValueSet:::OPTIONAL'),
+      border-right: enum('ValueSet:::OPTIONAL'),
+      border-color: enum('ValueSet:::OPTIONAL'),
       padding-right: 10px,
       text-align: right,
       vertical-align: top
@@ -62,7 +62,7 @@ $CodeSnippet__LineNumbers--Code: (
     _subselector: '',
     _properties: (
       font-size: 1.2rem,
-      font-family: enum('ValueSet:::REQUIRED'),
+      font-family: enum('ValueSet:::OPTIONAL'),
       padding-left: 0.5rem
     )
 );

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -43,27 +43,29 @@ $CodeBlock--Centered: (
 );
 
 //Styles specifically for code snippet tables
+$CodeSnippet__Container: empty_wrapper(CodeSnippet, '');
+
 $CodeSnippet__LineNumbers: (
     _name: 'CodeSnippetLineNumbers',
-    _subselector: '',
+    _subselector: '> .hljs-ln-line .hljs-ln-numbers',
     _properties: (
       font-size: 1.2rem,
-      font-family: enum('ValueSet:::OPTIONAL'),
-      border-right: enum('ValueSet:::OPTIONAL'),
-      border-color: enum('ValueSet:::OPTIONAL'),
+      font-family: enum('ValueSet:::REQUIRED'),
+      border-right: enum('ValueSet:::REQUIRED'),
+      border-color: enum('ValueSet:::REQUIRED'),
       padding-right: 10px,
-      text-align: enum('ValueSet:::OPTIONAL'),
+      text-align: enum('ValueSet:::REQUIRED'),
       vertical-align: top
     )
 );
 
 $CodeSnippet__LineNumbers--Code: (
     _name: 'CodeSnippetLineNumbersCode',
-    _subselector: '',
+    _subselector: '> .hljs-ln-line .hljs-ln-code',
     _properties: (
       font-size: 1.2rem,
-      font-family: enum('ValueSet:::OPTIONAL'),
+      font-family: enum('ValueSet:::REQUIRED'),
       padding-left: 0.5rem,
-      text-align: enum('ValueSet:::OPTIONAL'),
+      text-align: enum('ValueSet:::REQUIRED'),
     )
 );

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -47,7 +47,7 @@ $CodeSnippet__Container: empty_wrapper(CodeSnippet, '');
 
 $CodeSnippet__LineNumbers: (
     _name: 'CodeSnippetLineNumbers',
-    _subselector: '> .hljs-ln-line .hljs-ln-numbers',
+    _subselector: ' .hljs-ln-numbers',
     _properties: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::REQUIRED'),
@@ -61,7 +61,7 @@ $CodeSnippet__LineNumbers: (
 
 $CodeSnippet__LineNumbers--Code: (
     _name: 'CodeSnippetLineNumbersCode',
-    _subselector: '> .hljs-ln-line .hljs-ln-code',
+    _subselector: ' .hljs-ln-code',
     _properties: (
       font-size: 1.2rem,
       font-family: enum('ValueSet:::REQUIRED'),

--- a/styles/designs/webview/parts/_code-components.scss
+++ b/styles/designs/webview/parts/_code-components.scss
@@ -43,40 +43,26 @@ $CodeBlock--Centered: (
 );
 
 //Styles specifically for code snippet tables
-$CodeSnippetLineNumbers: (
+$CodeSnippet__LineNumbers: (
     _name: 'CodeSnippetLineNumbers',
     _subselector: '',
     _properties: (
-      font-size: font-scale(1),
+      font-size: 1.2rem,
       font-family: enum('ValueSet:::REQUIRED'),
       border-right: enum('ValueSet:::REQUIRED'),
-      padding-top: enum('ValueSet:::OPTIONAL'),
+      border-color: emum('ValueSet:::REQUIRED'),
       padding-right: 10px,
-      padding-bottom: enum('ValueSet:::OPTIONAL'),
-      padding-left: enum('ValueSet:::OPTIONAL'),
       text-align: right,
-      vertical-align: top,
-      border-top: enum('ValueSet:::OPTIONAL'),
-      border-bottom: enum('ValueSet:::OPTIONAL'),
-      border-left: enum('ValueSet:::OPTIONAL'),
-      border-style: enum('ValueSet:::OPTIONAL')
+      vertical-align: top
     )
 );
 
-$CodeSnippetLineNumbersCode: (
+$CodeSnippet__LineNumbers--Code: (
     _name: 'CodeSnippetLineNumbersCode',
     _subselector: '',
     _properties: (
-      font-size: font-scale(1),
+      font-size: 1.2rem,
       font-family: enum('ValueSet:::REQUIRED'),
-      border-top: enum('ValueSet:::OPTIONAL'),
-      border-right: enum('ValueSet:::OPTIONAL'),
-      border-bottom: enum('ValueSet:::OPTIONAL'),
-      border-left: enum('ValueSet:::OPTIONAL'),
-      border-style: enum('ValueSet:::OPTIONAL'),
-      padding-top: enum('ValueSet:::OPTIONAL'),
-      padding-right: enum('ValueSet:::OPTIONAL'),
-      padding-bottom: enum('ValueSet:::OPTIONAL'),
-      padding-left: 0.5rem !important
+      padding-left: 0.5rem
     )
 );

--- a/styles/designs/webview/parts/_code-shapes.scss
+++ b/styles/designs/webview/parts/_code-shapes.scss
@@ -33,11 +33,6 @@
 @include create_shape('webview:::CodeSnippetLineNumbersShape', (
   _components: (
     $CodeSnippet__LineNumbers,
-  ),
-));
-
-@include create_shape('webview:::CodeSnippetLineNumbersCodeShape', (
-  _components: (
     $CodeSnippet__LineNumbers--Code,
   ),
 ));

--- a/styles/designs/webview/parts/_code-shapes.scss
+++ b/styles/designs/webview/parts/_code-shapes.scss
@@ -32,12 +32,12 @@
 
 @include create_shape('webview:::CodeSnippetLineNumbersShape', (
   _components: (
-    $CodeSnippetLineNumbers,
+    $CodeSnippet__LineNumbers,
   ),
 ));
 
 @include create_shape('webview:::CodeSnippetLineNumbersCodeShape', (
   _components: (
-    $CodeSnippetLineNumbersCode,
+    $CodeSnippet__LineNumbers--Code,
   ),
 ));

--- a/styles/designs/webview/parts/_code-shapes.scss
+++ b/styles/designs/webview/parts/_code-shapes.scss
@@ -32,7 +32,10 @@
 
 @include create_shape('webview:::CodeSnippetLineNumbersShape', (
   _components: (
-    $CodeSnippet__LineNumbers,
-    $CodeSnippet__LineNumbers--Code,
-  ),
-));
+        map-merge($CodeSnippet__Container, (
+            _components: (
+              $CodeSnippet__LineNumbers--Code,
+              $CodeSnippet__LineNumbers,
+        )),
+    )),
+  ));

--- a/styles/designs/webview/parts/_code-shapes.scss
+++ b/styles/designs/webview/parts/_code-shapes.scss
@@ -29,3 +29,15 @@
       $CodeBlock--Centered,
     )
 ));
+
+@include create_shape('webview:::CodeSnippetLineNumbersShape', (
+  _components: (
+    $CodeSnippetLineNumbers,
+  ),
+));
+
+@include create_shape('webview:::CodeSnippetLineNumbersCodeShape', (
+  _components: (
+    $CodeSnippetLineNumbersCode,
+  ),
+));

--- a/styles/designs/webview/parts/_tables-components.scss
+++ b/styles/designs/webview/parts/_tables-components.scss
@@ -110,7 +110,7 @@ $Table__Head__Cell: (
 
 $Table__Data: (
   _name: "TableData",
-  _subselector: ' > td',
+  _subselector: ' > td:not(.hljs-ln-numbers .hljs-ln-code)',
   _properties: (
     border-width: 0.1rem,
     border-style: solid,
@@ -141,7 +141,7 @@ $Table__Cell--RightAligned: (
     _subselector: "[data-align="right"]",
     _properties: (
       text-align: right,
-    )    
+    )
 );
 
 $Table__MultipleBody: (

--- a/styles/designs/webview/parts/_tables-components.scss
+++ b/styles/designs/webview/parts/_tables-components.scss
@@ -110,7 +110,7 @@ $Table__Head__Cell: (
 
 $Table__Data: (
   _name: "TableData",
-  _subselector: ' > td:not(.hljs-ln-numbers .hljs-ln-code)',
+  _subselector: ' > td:not(.hljs-ln-numbers, .hljs-ln-code)',
   _properties: (
     border-width: 0.1rem,
     border-style: solid,

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -2549,6 +2549,21 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   color: #006767;
 }
 
+.hljs-ln-numbers {
+  font-size: 1.2rem;
+  font-family: Courier Prime, monospace;
+  border-right: solid 1pt #000000;
+  padding-right: 10px;
+  text-align: right;
+  vertical-align: top;
+}
+
+.hljs-ln-code {
+  font-size: 1.2rem;
+  font-family: Courier Prime, monospace;
+  padding-left: 0.5rem;
+}
+
 .os-eob[data-type=composite-chapter] > [data-type=composite-page] {
   margin-bottom: 1.4rem;
 }

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -2553,6 +2553,7 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   border-right: solid 1pt #000000;
+  border-color: #000000;
   padding-right: 10px;
   text-align: right;
   vertical-align: top;

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -2549,7 +2549,14 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   color: #006767;
 }
 
-.hljs-ln-numbers {
+.hljs-ln .hljs-ln-code {
+  font-size: 1.2rem;
+  font-family: Courier Prime, monospace;
+  padding-left: 0.5rem;
+  text-align: left;
+}
+
+.hljs-ln .hljs-ln-numbers {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   border-right: 1pt solid;
@@ -2557,24 +2564,6 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   padding-right: 10px;
   text-align: right;
   vertical-align: top;
-}
-
-.hljs-ln-numbers {
-  font-size: 1.2rem;
-  padding-left: 0.5rem;
-}
-
-.hljs-ln-code {
-  font-size: 1.2rem;
-  padding-right: 10px;
-  vertical-align: top;
-}
-
-.hljs-ln-code {
-  font-size: 1.2rem;
-  font-family: Courier Prime, monospace;
-  padding-left: 0.5rem;
-  text-align: left;
 }
 
 .os-eob[data-type=composite-chapter] > [data-type=composite-page] {

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -2552,7 +2552,7 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
 .hljs-ln-numbers {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
-  border-right: solid 1pt #000000;
+  border-right: 1pt solid;
   border-color: #000000;
   padding-right: 10px;
   text-align: right;
@@ -2567,7 +2567,6 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
 .hljs-ln-code {
   font-size: 1.2rem;
   padding-right: 10px;
-  text-align: right;
   vertical-align: top;
 }
 
@@ -2575,6 +2574,7 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   padding-left: 0.5rem;
+  text-align: left;
 }
 
 .os-eob[data-type=composite-chapter] > [data-type=composite-page] {

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -2559,6 +2559,18 @@ nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-unit-page) > ol > li > a::after 
   vertical-align: top;
 }
 
+.hljs-ln-numbers {
+  font-size: 1.2rem;
+  padding-left: 0.5rem;
+}
+
+.hljs-ln-code {
+  font-size: 1.2rem;
+  padding-right: 10px;
+  text-align: right;
+  vertical-align: top;
+}
+
 .hljs-ln-code {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2022,6 +2022,18 @@ blockquote {
   vertical-align: top;
 }
 
+.hljs-ln-numbers {
+  font-size: 1.2rem;
+  padding-left: 0.5rem;
+}
+
+.hljs-ln-code {
+  font-size: 1.2rem;
+  padding-right: 10px;
+  text-align: right;
+  vertical-align: top;
+}
+
 .hljs-ln-code {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2016,7 +2016,7 @@ blockquote {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   border-right: 1pt solid;
-  border-color: emum("ValueSet:::REQUIRED");
+  border-color: #000;
   padding-right: 10px;
   text-align: right;
   vertical-align: top;

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -1857,7 +1857,7 @@ a:hover {
   text-align: right;
 }
 
-.os-table table tbody > tr > td {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code) {
   border-width: 0.1rem;
   border-style: solid;
   border-color: #ddd;
@@ -1865,15 +1865,15 @@ a:hover {
   vertical-align: middle;
 }
 
-.os-table table tbody > tr > td[data-align=center] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=center] {
   text-align: center;
 }
 
-.os-table table tbody > tr > td[data-valign=top] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-valign=top] {
   vertical-align: top;
 }
 
-.os-table table tbody > tr > td[data-align=right] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=right] {
   text-align: right;
 }
 
@@ -1883,7 +1883,7 @@ a:hover {
   border-color: #ddd;
 }
 
-.os-table table tfoot > tr > td {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code) {
   border-width: 0.1rem;
   border-style: solid;
   border-color: #ddd;
@@ -1891,15 +1891,15 @@ a:hover {
   vertical-align: middle;
 }
 
-.os-table table tfoot > tr > td[data-align=center] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=center] {
   text-align: center;
 }
 
-.os-table table tfoot > tr > td[data-valign=top] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-valign=top] {
   vertical-align: top;
 }
 
-.os-table table tfoot > tr > td[data-align=right] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=right] {
   text-align: right;
 }
 
@@ -2016,28 +2016,15 @@ blockquote {
   font-size: font-scale(1);
   font-family: Courier Prime, monospace;
   border-right: 1pt solid #000000 !important;
-  padding-top: 0px !important;
   padding-right: 10px;
-  padding-bottom: 0px !important;
-  padding-left: 0px !important;
   text-align: right;
   vertical-align: top;
-  border-top: none !important;
-  border-bottom: none !important;
-  border-left: none !important;
 }
 
 .hljs-ln-code {
   font-size: font-scale(1);
   font-family: Courier Prime, monospace;
-  border-top: none !important;
-  border-right: none !important;
-  border-bottom: none !important;
   border-left: solid 1pt #000000 !important;
-  border-style: none !important;
-  padding-top: 0px !important;
-  padding-right: 0px !important;
-  padding-bottom: 0px !important;
   padding-left: 0.5rem;
 }
 

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2030,7 +2030,6 @@ blockquote {
 .hljs-ln-code {
   font-size: 1.2rem;
   padding-right: 10px;
-  text-align: right;
   vertical-align: top;
 }
 
@@ -2038,6 +2037,7 @@ blockquote {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   padding-left: 0.5rem;
+  text-align: left;
 }
 
 .primary-function, .secondary-function {

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2012,14 +2012,14 @@ blockquote {
   color: #006767;
 }
 
-.hljs-ln > .hljs-ln-line .hljs-ln-code {
+.hljs-ln .hljs-ln-code {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   padding-left: 0.5rem;
   text-align: left;
 }
 
-.hljs-ln > .hljs-ln-line .hljs-ln-numbers {
+.hljs-ln .hljs-ln-numbers {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   border-right: 1pt solid;

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2025,7 +2025,6 @@ blockquote {
 .hljs-ln-numbers {
   font-size: 1.2rem;
   padding-left: 0.5rem;
-  text-align: left;
 }
 
 .hljs-ln-code {
@@ -2039,7 +2038,6 @@ blockquote {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   padding-left: 0.5rem;
-  text-align: left;
 }
 
 .primary-function, .secondary-function {

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -1857,7 +1857,7 @@ a:hover {
   text-align: right;
 }
 
-.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code) {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers, .hljs-ln-code) {
   border-width: 0.1rem;
   border-style: solid;
   border-color: #ddd;
@@ -1865,15 +1865,15 @@ a:hover {
   vertical-align: middle;
 }
 
-.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=center] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-align=center] {
   text-align: center;
 }
 
-.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-valign=top] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-valign=top] {
   vertical-align: top;
 }
 
-.os-table table tbody > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=right] {
+.os-table table tbody > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-align=right] {
   text-align: right;
 }
 
@@ -1883,7 +1883,7 @@ a:hover {
   border-color: #ddd;
 }
 
-.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code) {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers, .hljs-ln-code) {
   border-width: 0.1rem;
   border-style: solid;
   border-color: #ddd;
@@ -1891,15 +1891,15 @@ a:hover {
   vertical-align: middle;
 }
 
-.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=center] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-align=center] {
   text-align: center;
 }
 
-.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-valign=top] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-valign=top] {
   vertical-align: top;
 }
 
-.os-table table tfoot > tr > td:not(.hljs-ln-numbers .hljs-ln-code)[data-align=right] {
+.os-table table tfoot > tr > td:not(.hljs-ln-numbers, .hljs-ln-code)[data-align=right] {
   text-align: right;
 }
 

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2012,6 +2012,35 @@ blockquote {
   color: #006767;
 }
 
+.hljs-ln-numbers {
+  font-size: font-scale(1);
+  font-family: Courier Prime, monospace;
+  border-right: 1pt solid #000000 !important;
+  padding-top: 0px !important;
+  padding-right: 10px;
+  padding-bottom: 0px !important;
+  padding-left: 0px !important;
+  text-align: right;
+  vertical-align: top;
+  border-top: none !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+.hljs-ln-code {
+  font-size: font-scale(1);
+  font-family: Courier Prime, monospace;
+  border-top: none !important;
+  border-right: none !important;
+  border-bottom: none !important;
+  border-left: solid 1pt #000000 !important;
+  border-style: none !important;
+  padding-top: 0px !important;
+  padding-right: 0px !important;
+  padding-bottom: 0px !important;
+  padding-left: 0.5rem;
+}
+
 .primary-function, .secondary-function {
   font-family: "IBM Plex Mono", monospace;
 }

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2025,6 +2025,7 @@ blockquote {
 .hljs-ln-numbers {
   font-size: 1.2rem;
   padding-left: 0.5rem;
+  text-align: left;
 }
 
 .hljs-ln-code {
@@ -2038,6 +2039,7 @@ blockquote {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   padding-left: 0.5rem;
+  text-align: left;
 }
 
 .primary-function, .secondary-function {

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2013,18 +2013,18 @@ blockquote {
 }
 
 .hljs-ln-numbers {
-  font-size: font-scale(1);
+  font-size: 1.2rem;
   font-family: Courier Prime, monospace;
-  border-right: 1pt solid #000000 !important;
+  border-right: 1pt solid;
+  border-color: emum("ValueSet:::REQUIRED");
   padding-right: 10px;
   text-align: right;
   vertical-align: top;
 }
 
 .hljs-ln-code {
-  font-size: font-scale(1);
+  font-size: 1.2rem;
   font-family: Courier Prime, monospace;
-  border-left: solid 1pt #000000 !important;
   padding-left: 0.5rem;
 }
 

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2012,7 +2012,14 @@ blockquote {
   color: #006767;
 }
 
-.hljs-ln-numbers {
+.hljs-ln > .hljs-ln-line .hljs-ln-code {
+  font-size: 1.2rem;
+  font-family: Courier Prime, monospace;
+  padding-left: 0.5rem;
+  text-align: left;
+}
+
+.hljs-ln > .hljs-ln-line .hljs-ln-numbers {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;
   border-right: 1pt solid;
@@ -2020,24 +2027,6 @@ blockquote {
   padding-right: 10px;
   text-align: right;
   vertical-align: top;
-}
-
-.hljs-ln-numbers {
-  font-size: 1.2rem;
-  padding-left: 0.5rem;
-}
-
-.hljs-ln-code {
-  font-size: 1.2rem;
-  padding-right: 10px;
-  vertical-align: top;
-}
-
-.hljs-ln-code {
-  font-size: 1.2rem;
-  font-family: Courier Prime, monospace;
-  padding-left: 0.5rem;
-  text-align: left;
 }
 
 .primary-function, .secondary-function {


### PR DESCRIPTION
Issue: [5350](https://github.com/openstax/cnx-recipes/issues/5350#issue-2017000840)

**PDF:**
<img width="1102" alt="Screenshot 2024-01-22 at 6 05 55 PM" src="https://github.com/openstax/ce-styles/assets/26155528/21346f85-09ac-418a-a809-d631b38b74f6">

**Webview:** 
<img width="1545" alt="Screenshot 2024-01-24 at 11 25 32 AM" src="https://github.com/openstax/ce-styles/assets/26155528/69c0ea65-8567-4486-be8c-282b816bad2d">

