### PR TITLE
change future-tech note color in information-systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Change `future-tech` note color in `information-systems`
 * Style `green-code` in `data-science` and on `webview`
 * Style `vertically-tight` tables in `information-systems`
 

--- a/styles/books/information-systems/book.scss
+++ b/styles/books/information-systems/book.scss
@@ -144,10 +144,10 @@ TextHeavyWithTitleTable: (
     FutureTech: (
         _selectors: (".future-tech"),
         "Title:::background-color": (_ref: "colorMap:::noteOption2HeaderBackgroundColor"),
-        "Title:::color": (_ref: "colorMap:::noteOption2HeaderColor"),
+        "Title:::color": (_ref: "colorMap:::noteOption5HeaderColor"),
         "Title:::font-family": (_ref: "typography:::titleFont"),
         "Body:::font-family": (_ref: "typography:::baseFont"),
-        "Body:::background-color": (_ref: "colorMap:::noteOption2BodyBackgroundColor"),
+        "Body:::background-color": (_ref: "colorMap:::noteOption5BodyBackgroundColor"),
         "Subtitle:::color": (_ref: "colorMap:::noteSubtitleColor"),
         "Subtitle:::font-family": (_ref: "typography:::titleFont"),
         "ProblemSolutionTitle:::font-family": (_ref: "typography:::baseFont")

--- a/styles/output/information-systems-pdf.css
+++ b/styles/output/information-systems-pdf.css
@@ -3405,7 +3405,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   font-family: Noto Sans, StixGeneral;
   font-size: 1rem;
   line-height: 1.5rem;
-  background-color: #D3E3EB;
+  background-color: #D6D9DD;
   padding: 0.7rem;
 }
 


### PR DESCRIPTION
Issue: [5506](https://github.com/openstax/cnx-recipes/issues/5506)

<img width="872" alt="Screenshot 2024-04-12 at 4 09 05 PM" src="https://github.com/openstax/ce-styles/assets/26155528/26dc6dcd-b043-4d14-89e5-34a1b38a21af">
