### PR TITLE
Unnumbered `Learning Objectives` in `computer-science`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Unnumbered `Learning Objectives` in `computer-science`
 * Style `answer-key` in `neuroscience`
 * Add check for whether output compiled to CI
 * Rewrite `build.dart` to `build.js` and remove dart

--- a/styles/books/computer-science/book.scss
+++ b/styles/books/computer-science/book.scss
@@ -171,7 +171,7 @@ $bandColor: #24739E;
 @include use('TableAfterExercisePara', 'cardboard:::TableTopSpacingShape');
 
 // Learning objectives
-@include cardboard.learning-objectives--numbered();
+@include use('LearningObjectives', 'cardboard:::LearningObjectivesShape');
 
 // Code
 @include cardboard.hljs-colors();

--- a/styles/output/computer-science-pdf.css
+++ b/styles/output/computer-science-pdf.css
@@ -3498,28 +3498,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-top: 1rem;
 }
 
-[data-type=page] .learning-objectives > h3[data-type=title] {
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > h3[data-type=title] {
   color: #24739E;
-  font-family: Noto Sans, StixGeneral;
+  font-family: Noto Sans, sans-serif, StixGeneral;
   font-size: 1.2rem;
   line-height: 1.5rem;
   font-weight: bold;
   margin-bottom: 0;
 }
-[data-type=page] .learning-objectives > p:first-of-type {
+
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > p:first-of-type {
   margin: 0;
 }
-[data-type=page] .learning-objectives > ul {
-  list-style-type: none;
+
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > ul:not([data-labeled-item=true]) {
+  margin-left: 24px;
 }
-[data-type=page] .learning-objectives > ul > li {
-  display: flex;
+
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > ul:not([data-labeled-item=true]) > li {
   max-width: 5.9in;
 }
-[data-type=page] .learning-objectives > ul > li > span.os-abstract-token {
-  font-weight: bold;
-  margin-right: 8px;
-  color: #344456;
+
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > ol {
+  margin-left: 24px;
+}
+
+[data-type=page]:not(.introduction):not(.unit-opener) .learning-objectives > ol > li {
+  max-width: 5.9in;
 }
 
 .hljs-comment {


### PR DESCRIPTION
part of openstax/cnx-recipes#5574

Learning Objectives without numbering (as seen in PDF output):

<img width="666" alt="Screenshot 2024-07-15 at 3 08 20 PM" src="https://github.com/user-attachments/assets/ce41e14f-06b7-448f-a44c-8cc82b02b7b7">
