### PR TITLE
5594 bold answer letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reenable local fonts for PDF/EPUB
 - Style lists at third section level in `cardboard`
 - `Data Science`: Table Vertical alignment
+- Add `ProblemSolutionAnswerLetters` component for `answer-letters` to `cardboard`
+- Style `answer-letters` in bold in `data-science`
+- Style `answer-letters` in bold in `webview`
 
 ## [v2.4.0] - 2024-08-23
 

--- a/styles/books/data-science/book.scss
+++ b/styles/books/data-science/book.scss
@@ -115,6 +115,12 @@ $bandColor: #24739E;
   ),
 ));
 
+@include add_settings((
+  "AnswerKeySolution:::ProblemSolutionAnswerLetters": (
+    font-weight: bold,
+  )
+));
+
 
 @include use('BookRoot', "common:::BookRoot");
 @include use('Footnote', 'common:::FootnoteShape');

--- a/styles/designs/cardboard/parts/_answerkey-shapes.scss
+++ b/styles/designs/cardboard/parts/_answerkey-shapes.scss
@@ -24,6 +24,7 @@
               map-merge($Exercise__Solution__Container, (
                   _components: (
                       $Exercise__ProblemSolution__Para,
+                      $Exercise__ProblemSolution__AnswerLetters,
                   )
               )),
               $Exercise__Solution__Container--WithFirstElement,

--- a/styles/designs/cardboard/parts/_exercises-components.scss
+++ b/styles/designs/cardboard/parts/_exercises-components.scss
@@ -211,3 +211,10 @@ $Exercise__ProblemSolution__Para: (
   )
 );
 
+$Exercise__ProblemSolution__AnswerLetters: (
+  _name: "ProblemSolutionAnswerLetters",
+  _subselector: " > span.answer-letters",
+  _properties: (
+    font-weight: enum('ValueSet:::OPTIONAL')
+  )
+);

--- a/styles/lib/webview/features/_answer-key.scss
+++ b/styles/lib/webview/features/_answer-key.scss
@@ -21,6 +21,9 @@
         img {
           margin-top: 0;
         }
+        > span.answer-letters {
+          font-weight: bold;
+        }
       }
     }
     // Injected solutions

--- a/styles/output/data-science-pdf.css
+++ b/styles/output/data-science-pdf.css
@@ -3963,6 +3963,10 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 0;
 }
 
+.os-eob [data-type=solution] > .os-solution-container > span.answer-letters {
+  font-weight: bold;
+}
+
 .os-eob [data-type=solution] > .os-solution-container.has-first-element {
   display: table-cell;
   vertical-align: bottom;
@@ -3994,6 +3998,10 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-eob [data-type=question-solution] > .os-solution-container > p {
   margin-bottom: 0;
+}
+
+.os-eob [data-type=question-solution] > .os-solution-container > span.answer-letters {
+  font-weight: bold;
 }
 
 .os-eob [data-type=question-solution] > .os-solution-container.has-first-element {

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -2005,6 +2005,9 @@ section.further-reading p {
 .os-eob [data-type=solution] > .os-solution-container img, .os-eob [data-type=question-solution] > .os-solution-container img {
   margin-top: 0;
 }
+.os-eob [data-type=solution] > .os-solution-container > span.answer-letters, .os-eob [data-type=question-solution] > .os-solution-container > span.answer-letters {
+  font-weight: bold;
+}
 .os-eob [data-type=question-solution] > .os-prefix {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
part of openstax/cnx-recipes#5594

Make `answer-letters` bold in `data-science` and `webview`

PDF Preview:
<img width="691" alt="Screenshot 2024-08-28 at 11 07 40 AM" src="https://github.com/user-attachments/assets/065de969-285b-4c24-b73b-50056cfec43c">

Web Preview:
<img width="691" alt="Screenshot 2024-08-28 at 3 06 33 PM" src="https://github.com/user-attachments/assets/dbedcc59-5c60-4ebe-a03a-f273b2b2aa8c">
