### PR TITLE
Add brown text color for data science

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ProblemSolutionAnswerLetters` component for `answer-letters` to `cardboard`
 - Style `answer-letters` in bold in `data-science`
 - Style `answer-letters` in bold in `webview`
+- Style `brown-code` in `data-science` and on `webview`
 
 ## [v2.4.0] - 2024-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Style `brown-code` in `data-science` and on `webview`
 
 
 ## [v2.5.0] - 2024-09-09
@@ -17,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ProblemSolutionAnswerLetters` component for `answer-letters` to `cardboard`
 - Style `answer-letters` in bold in `data-science`
 - Style `answer-letters` in bold in `webview`
-- Style `brown-code` in `data-science` and on `webview`
 
 ## [v2.4.0] - 2024-08-23
 

--- a/styles/books/data-science/book.scss
+++ b/styles/books/data-science/book.scss
@@ -134,6 +134,7 @@ $bandColor: #24739E;
 // Code
 @include cardboard.hljs-colors();
 @include cardboard.green-code();
+@include cardboard.brown-code();
 
 // Titles
 @include use('ChapterTitles', 'cardboard:::ChapterTitlesShape');

--- a/styles/books/generic/webview.scss
+++ b/styles/books/generic/webview.scss
@@ -387,6 +387,7 @@
 // Code Snippets
 @include webview.hljs-colors();
 @include webview.green-code();
+@include webview.brown-code();
 @include use('CodeSnippet', 'webview:::CodeSnippetLineNumbersShape');
 
 // Functions

--- a/styles/lib/cardboard/features/_code-colors.scss
+++ b/styles/lib/cardboard/features/_code-colors.scss
@@ -57,3 +57,10 @@
     font-family: fonts.$monospace;
   }
 }
+
+@mixin brown-code() {
+  .brown-code {
+    color: colors.$BR1;
+    font-family: fonts.$monospace;
+  }
+}

--- a/styles/output/data-science-pdf.css
+++ b/styles/output/data-science-pdf.css
@@ -1367,6 +1367,11 @@ nav#toc > ol > li.os-toc-composite-chapter > ol {
   font-family: Courier Prime, monospace;
 }
 
+.brown-code {
+  color: #A35200;
+  font-family: Courier Prime, monospace;
+}
+
 [data-type=chapter] {
   height: 100%;
   position: relative;

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -1502,6 +1502,11 @@ blockquote {
   font-family: Courier Prime, monospace;
 }
 
+.brown-code {
+  color: #A35200;
+  font-family: Courier Prime, monospace;
+}
+
 .hljs-ln .hljs-ln-code {
   font-size: 1.2rem;
   font-family: Courier Prime, monospace;


### PR DESCRIPTION
part of [openstax/cnx-recipes#5623](https://github.com/openstax/cnx-recipes/issues/5623)

Add BR1 (#A35200) and monospace font to `data-science` and `webview`.