### PR TITLE
Allow exercise figure max-width to be adjusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+
+## [v2.9.0] - 2025-02-10
+
 - Style more third level lists in `cardboard`
 - Fix typo in third level list name in `cardboard`
 - Add `lists from stimulus` to `cardboard`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typo in third level list name in `cardboard`
 - Add `lists from stimulus` to `cardboard`
 - Style `lists from stimulus` in `information-systems`
+- Align `ProblemSolutionLetter` right in `carnival`
+- Set `max-width` of `FigureFromExercises` to 95% in `carnival`
 
 ## [v2.8.0] - 2025-01-16
 

--- a/styles/books/anatomy/book.scss
+++ b/styles/books/anatomy/book.scss
@@ -110,14 +110,17 @@ $ChapterIntroType: fullWidth;
   InteractiveExercise: (
     _selectors: ("[data-type = 'chapter'] > .os-interactive-exercise-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   MultipleChoice: (
     _selectors: ("[data-type = 'chapter'] > .os-multiple-choice-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   FreeResponse: (
     _selectors: ("[data-type = 'chapter'] > .os-free-response-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/books/anthropology/book.scss
+++ b/styles/books/anthropology/book.scss
@@ -122,6 +122,7 @@ $ChapterIntroType: fullWidth;
   CriticalThinking: (
     _selectors: ('[data-type = "chapter"] > .os-critical-thinking-container'),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/books/college-physics/book.scss
+++ b/styles/books/college-physics/book.scss
@@ -76,10 +76,12 @@ $ChapterIntroType: fullWidth;
   ConceptualQuestions: (
     _selectors: ("[data-type = 'chapter'] > .os-conceptual-questions-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ProblemsExercises: (
     _selectors: ("[data-type = 'chapter'] > .os-problems-exercises-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/books/hs-physics/book.scss
+++ b/styles/books/hs-physics/book.scss
@@ -134,30 +134,37 @@ $ChapterIntroType: fullWidth;
   ConceptCompChapPage:(
     _selectors: (".os-concept-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   CriticalThinkingCompChapPage:(
     _selectors: (".os-critical-thinking-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ProblemsCompChapPage:(
     _selectors: (".os-problems-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   PerformanceCompChapPage:(
     _selectors: (".os-performance-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   MultipleChoiceCompChapPage:(
     _selectors: (".os-multiple-choice-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ShortAnswerCompChapPage:(
     _selectors: (".os-short-answer-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ExtendedResponseCompChapPage:(
     _selectors: (".os-extended-response-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/books/nursing-external/book.scss
+++ b/styles/books/nursing-external/book.scss
@@ -391,6 +391,30 @@ $ChapterIntroType: fullWidth;
   ),
 ));
 
+@include add_settings((
+  FigureFromExercisesProblem: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromExercisesSolution: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromInjectedQuestion: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromInjectedSolution: (
+    'Image:::max-width': 100%,
+  )
+));
+
 
 // Common Settings
 @include use('BookRoot', "common:::BookRoot");

--- a/styles/books/nursing-internal/book.scss
+++ b/styles/books/nursing-internal/book.scss
@@ -196,6 +196,30 @@ $ChapterIntroType: fullWidth;
   ),
 ));
 
+@include add_settings((
+  FigureFromExercisesProblem: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromExercisesSolution: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromInjectedQuestion: (
+    'Image:::max-width': 100%,
+  )
+));
+
+@include add_settings((
+  FigureFromInjectedSolution: (
+    'Image:::max-width': 100%,
+  )
+));
+
 
 // Common Settings
 @include use('BookRoot', "common:::BookRoot");

--- a/styles/books/organic-chemistry/book.scss
+++ b/styles/books/organic-chemistry/book.scss
@@ -146,26 +146,32 @@ nav, [data-type="document-title"], [data-type="title"],
     VisualizingChemistry:(
         _selectors: (".os-visualizing-chemistry-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
     AdditionalProblems:(
         _selectors: (".os-additional-problems-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
     MechanismProblems:(
         _selectors: (".os-mechanism-problems-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
     GeneralProblems:(
         _selectors: (".os-general-problems-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
     EnergyReaction:(
         _selectors: (".os-energy-reaction-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
     CarbonylChemistry:(
         _selectors: (".os-preview-carbonylchemistry-container"),
         'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'ProblemSolutionNumber:::text-align': right,
     ),
 ));
 

--- a/styles/books/pl-u-physics/book.scss
+++ b/styles/books/pl-u-physics/book.scss
@@ -89,18 +89,22 @@ $ChapterIntroType: fullWidth;
   ConceptualQuestionsCompChapPage:(
     _selectors: (".os-review-conceptual-questions-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ProblemsCompChapPage:(
     _selectors: (".os-review-problems-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   AdditionalProblemsCompChapPage:(
     _selectors: (".os-review-additional-problems-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ChallengeProblemsCompChapPage:(
     _selectors: (".os-review-challenge-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/books/u-physics/book.scss
+++ b/styles/books/u-physics/book.scss
@@ -50,18 +50,22 @@ $ChapterIntroType: fullWidth;
   ConceptualQuestionsCompChapPage:(
     _selectors: (".os-review-conceptual-questions-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ProblemsCompChapPage:(
     _selectors: (".os-review-problems-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   AdditionalProblemsCompChapPage:(
     _selectors: (".os-review-additional-problems-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
   ChallengeProblemsCompChapPage:(
     _selectors: (".os-review-challenge-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
   ),
 ));
 

--- a/styles/design-settings/carnival/parts/_figureimage-settings.scss
+++ b/styles/design-settings/carnival/parts/_figureimage-settings.scss
@@ -18,27 +18,19 @@
     ),
     FigureFromExercisesProblem:(
       _selectors: ('[data-type="problem"]'),
-      Image: (
-        max-width: 95%,
-      ),
+      'Image:::max-width': 95%,
     ),
     FigureFromExercisesSolution:(
       _selectors: ('[data-type="solution"]'),
-      Image: (
-        max-width: 95%,
-      ),
+      'Image:::max-width': 95%,
     ),
     FigureFromInjectedQuestion:(
       _selectors: ('[data-type="exercise-question"]'),
-      Image: (
-        max-width: 95%,
-      ),
+      'Image:::max-width': 95%,
     ),
     FigureFromInjectedSolution:(
       _selectors: ('[data-type="question-solution"]'),
-      Image: (
-        max-width: 95%,
-      ),
+      'Image:::max-width': 95%,
     ),
     FigureAfterSubtitle: (
       _selectors: ("h4.os-subtitle + .os-figure:not(.has-splash)"),

--- a/styles/design-settings/carnival/parts/_figureimage-settings.scss
+++ b/styles/design-settings/carnival/parts/_figureimage-settings.scss
@@ -18,15 +18,27 @@
     ),
     FigureFromExercisesProblem:(
       _selectors: ('[data-type="problem"]'),
+      Image: (
+        max-width: 95%,
+      ),
     ),
     FigureFromExercisesSolution:(
       _selectors: ('[data-type="solution"]'),
+      Image: (
+        max-width: 95%,
+      ),
     ),
     FigureFromInjectedQuestion:(
       _selectors: ('[data-type="exercise-question"]'),
+      Image: (
+        max-width: 95%,
+      ),
     ),
     FigureFromInjectedSolution:(
       _selectors: ('[data-type="question-solution"]'),
+      Image: (
+        max-width: 95%,
+      ),
     ),
     FigureAfterSubtitle: (
       _selectors: ("h4.os-subtitle + .os-figure:not(.has-splash)"),

--- a/styles/designs/carnival/parts/_figureimage-components.scss
+++ b/styles/designs/carnival/parts/_figureimage-components.scss
@@ -89,7 +89,7 @@ $Image: (
     _name: "Image",
     _subselector: " img",
     _properties:(
-        max-width: 100%,
+        max-width: enum("ValueSet:::REQUIRED"),
     )
 );
 

--- a/styles/output/anatomy-pdf.css
+++ b/styles/output/anatomy-pdf.css
@@ -1347,7 +1347,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1368,7 +1368,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -2724,6 +2724,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2770,6 +2771,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2818,6 +2820,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2864,6 +2867,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2912,6 +2916,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2958,6 +2963,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/anthropology-pdf.css
+++ b/styles/output/anthropology-pdf.css
@@ -2578,7 +2578,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -2599,7 +2599,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -2941,6 +2941,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2987,6 +2988,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/ap-biology-pdf.css
+++ b/styles/output/ap-biology-pdf.css
@@ -1499,7 +1499,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1520,7 +1520,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/ap-physics-2e-pdf.css
+++ b/styles/output/ap-physics-2e-pdf.css
@@ -1439,7 +1439,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1460,7 +1460,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1829,6 +1829,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1875,6 +1876,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1923,6 +1925,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1969,6 +1972,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/ap-physics-pdf.css
+++ b/styles/output/ap-physics-pdf.css
@@ -1439,7 +1439,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1460,7 +1460,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1829,6 +1829,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1875,6 +1876,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1923,6 +1925,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1969,6 +1972,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/biology-pdf.css
+++ b/styles/output/biology-pdf.css
@@ -1499,7 +1499,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1520,7 +1520,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/chemistry-pdf.css
+++ b/styles/output/chemistry-pdf.css
@@ -1433,7 +1433,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1454,7 +1454,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1475,7 +1475,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1496,7 +1496,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/college-physics-2e-pdf.css
+++ b/styles/output/college-physics-2e-pdf.css
@@ -1439,7 +1439,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1460,7 +1460,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1829,6 +1829,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1875,6 +1876,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1923,6 +1925,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1969,6 +1972,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3400,7 +3404,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -3421,7 +3425,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/college-physics-pdf.css
+++ b/styles/output/college-physics-pdf.css
@@ -1439,7 +1439,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1460,7 +1460,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1829,6 +1829,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1875,6 +1876,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1923,6 +1925,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -1969,6 +1972,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/hs-physics-pdf.css
+++ b/styles/output/hs-physics-pdf.css
@@ -1479,7 +1479,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1500,7 +1500,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1979,6 +1979,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2025,6 +2026,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2073,6 +2075,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2119,6 +2122,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2167,6 +2171,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2213,6 +2218,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2261,6 +2267,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2307,6 +2314,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2355,6 +2363,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2401,6 +2410,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2449,6 +2459,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2495,6 +2506,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2543,6 +2555,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2589,6 +2602,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/microbiology-pdf.css
+++ b/styles/output/microbiology-pdf.css
@@ -1590,7 +1590,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1611,7 +1611,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/nursing-external-pdf.css
+++ b/styles/output/nursing-external-pdf.css
@@ -1416,7 +1416,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1437,7 +1437,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1458,7 +1458,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1479,7 +1479,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/nursing-external-pdf.css
+++ b/styles/output/nursing-external-pdf.css
@@ -1416,7 +1416,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1437,7 +1437,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1458,7 +1458,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1479,7 +1479,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/nursing-internal-pdf.css
+++ b/styles/output/nursing-internal-pdf.css
@@ -1725,7 +1725,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1746,7 +1746,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1767,7 +1767,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1788,7 +1788,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 95%;
+  max-width: 100%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/nursing-internal-pdf.css
+++ b/styles/output/nursing-internal-pdf.css
@@ -1725,7 +1725,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1746,7 +1746,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1767,7 +1767,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1788,7 +1788,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {

--- a/styles/output/organic-chemistry-pdf.css
+++ b/styles/output/organic-chemistry-pdf.css
@@ -2794,7 +2794,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -2815,7 +2815,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -2836,7 +2836,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -2857,7 +2857,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {
@@ -3357,6 +3357,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3403,6 +3404,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3451,6 +3453,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3497,6 +3500,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3545,6 +3549,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3591,6 +3596,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3639,6 +3645,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3685,6 +3692,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3733,6 +3741,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3779,6 +3788,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3827,6 +3837,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3873,6 +3884,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/pl-u-physics-pdf.css
+++ b/styles/output/pl-u-physics-pdf.css
@@ -1502,7 +1502,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1523,7 +1523,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1544,7 +1544,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1565,7 +1565,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {
@@ -1990,6 +1990,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2036,6 +2037,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2084,6 +2086,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2130,6 +2133,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2178,6 +2182,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2224,6 +2229,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2272,6 +2278,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2318,6 +2325,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 

--- a/styles/output/u-physics-pdf.css
+++ b/styles/output/u-physics-pdf.css
@@ -1671,7 +1671,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=problem] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=problem] > div > ol > li > .os-figure:first-child img {
@@ -1692,7 +1692,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=solution] > div > ol > li > .os-figure:first-child img {
@@ -1713,7 +1713,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=exercise-question] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=exercise-question] > div > ol > li > .os-figure:first-child img {
@@ -1734,7 +1734,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 }
 
 [data-type=question-solution] img {
-  max-width: 100%;
+  max-width: 95%;
 }
 
 [data-type=question-solution] > div > ol > li > .os-figure:first-child img {
@@ -1981,6 +1981,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2027,6 +2028,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2075,6 +2077,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2121,6 +2124,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2169,6 +2173,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2215,6 +2220,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2263,6 +2269,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -2309,6 +2316,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-723

Backstory: Around 1 year ago, the min-width of the problem solution number was increased to 24px for the entire carnival theme and I guess the related parts, that I am trying to fix here, were not accounted for back then 💥.

```python
# And the lucky randomly selected person is...
reviewers[int(urandom(1)[0] / 255 * len(reviewers))]
'Josiah'
```

1. Align os-number right for exercises
1. Reduce max size of images in exercises to 95%
1. Fix same alignment and image problems in other books

First I tried changing the column-gap, but the images seemed to like overflowing past the bounds of the column. I think this may be related to how princexml handles image size. Reducing the max image size inside exercises gave better results.

I think I updated all instances of `ProblemSolutionNumber` in carnival (`find styles/books/ -type f -exec grep -l 'carnival' {} \+ | xargs -d'\n' grep ProblemSolutionNumber` doesn't show any missing text-align setting).

## Before

<img width="507" alt="Screenshot 2025-02-04 at 11 48 55 AM" src="https://github.com/user-attachments/assets/e2a4905e-2cdf-4529-9414-f45cdac260a2" />

## After

<img width="882" alt="Screenshot 2025-02-06 at 4 20 31 PM" src="https://github.com/user-attachments/assets/392e4102-6349-4ad7-8a0d-0ac6c90e5957" />
