### PR TITLE
Add margin for first level lists inside tables in `corn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add margin for first level lists inside tables in `corn`
 
 
 ## [v2.9.0] - 2025-02-10

--- a/styles/designs/corn/parts/_table-shapes.scss
+++ b/styles/designs/corn/parts/_table-shapes.scss
@@ -27,10 +27,30 @@
                             _components: (
                                 map-merge($Table__Row, (
                                     _components: (
-                                      $Table__Data,
-                                      $Table__Data--LeftAligned,
-                                      $Table__Data--RightAligned,
-                                      $Table__Data--Centered,
+                                      map-merge($Table__Data, (
+                                        _components: (
+                                            $UnorderedList--FirstLevel,
+                                            $OrderedList--FirstLevel,
+                                        )
+                                      )),
+                                      map-merge($Table__Data--LeftAligned, (
+                                        _components: (
+                                            $UnorderedList--FirstLevel,
+                                            $OrderedList--FirstLevel,
+                                        )
+                                      )),
+                                      map-merge($Table__Data--RightAligned, (
+                                        _components: (
+                                            $UnorderedList--FirstLevel,
+                                            $OrderedList--FirstLevel,
+                                        )
+                                      )),
+                                      map-merge($Table__Data--Centered, (
+                                        _components: (
+                                            $UnorderedList--FirstLevel,
+                                            $OrderedList--FirstLevel,
+                                        )
+                                      )),
                                     )
                                 )),
                                 map-merge($Table__Row--Last, (

--- a/styles/output/additive-manufacturing-pdf.css
+++ b/styles/output/additive-manufacturing-pdf.css
@@ -1492,16 +1492,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -2691,16 +2691,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {
@@ -2949,16 +2981,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table.os-data-table-container > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table.os-data-table-container > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/contemporary-math-pdf.css
+++ b/styles/output/contemporary-math-pdf.css
@@ -2971,16 +2971,48 @@ li > table {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/dev-math-pdf.css
+++ b/styles/output/dev-math-pdf.css
@@ -3100,16 +3100,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/precalculus-coreq-pdf.css
+++ b/styles/output/precalculus-coreq-pdf.css
@@ -2954,16 +2954,48 @@ section.coreq-skills > section.learning-objectives > ul > li {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/precalculus-pdf.css
+++ b/styles/output/precalculus-pdf.css
@@ -3012,16 +3012,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {

--- a/styles/output/statistics-pdf.css
+++ b/styles/output/statistics-pdf.css
@@ -1583,16 +1583,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:first-child {
@@ -1683,16 +1715,48 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
+.os-table.os-data-table-container > table > tbody > tr > td > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=left] {
   text-align: left;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=left] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=left] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=right] {
   text-align: right;
 }
 
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=right] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=right] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
+}
+
 .os-table.os-data-table-container > table > tbody > tr > td[data-align=center] {
   text-align: center;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=center] > ul:not(.circled):not(.os-stepwise):not([data-labeled-item=true]) {
+  margin-left: 24px;
+}
+
+.os-table.os-data-table-container > table > tbody > tr > td[data-align=center] > ol:not(.circled):not(.os-stepwise) {
+  margin-left: 24px;
 }
 
 .os-table.os-data-table-container > table > tbody > tr:last-of-type > td:first-child {


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-769

## Explanation
List margins in tables are already supported in other themes, like cosmos, it just needed to be added to corn.

## Additional background
In pdfs, the default margin/padding for lists is 0px. If a list appears somewhere that is not accounted for in the theme, in this case tables, then they will have their default margin/padding.

## Before
<img width="789" alt="Image" src="https://github.com/user-attachments/assets/847c3edf-24fc-46a2-9b16-37b2e8345f8c" />

## After
<img width="882" alt="Screenshot 2025-02-13 at 11 04 53 AM" src="https://github.com/user-attachments/assets/58c461f0-9990-470b-b4e1-97e2cca588de" />

---

I am picking a reviewer at random:
```python
from os import urandom
reviewers = "dante roy josiah jose tom beth prabhdip".split(" ")
reviewers[int(urandom(1)[0] / 255 * len(reviewers))]
'roy'
```