### PR TITLE
Remove set width from equation number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove set `width` from `EquationNumberContainer` on `webview`
 
 ## [v2.10.0] - 2025-02-25
 

--- a/styles/designs/webview/parts/_equation-components.scss
+++ b/styles/designs/webview/parts/_equation-components.scss
@@ -23,7 +23,7 @@ $Equation__Number__Container: (
   _name: "EquationNumberContainer",
   _subselector: ' .os-equation-number',
   _properties: (
-    width: 5%,
+    width: auto,
     vertical-align: middle,
     margin-left: 1em,
   ),

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -1700,7 +1700,7 @@ a[data-type=cite] {
 }
 
 [data-type=equation]:not(.unnumbered) .os-equation-number {
-  width: 5%;
+  width: auto;
   vertical-align: middle;
   margin-left: 1em;
 }


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-863

This width is no longer needed with `display: flex` set on `EquationContainerNumbered` and it created wrapping problems.

## With Set Width
<img width="833" alt="Screenshot 2025-04-08 at 1 14 06 PM" src="https://github.com/user-attachments/assets/912f3127-7149-4c75-9396-8346d8e3a2f1" />

## Without Set Width
<img width="833" alt="Screenshot 2025-04-08 at 1 14 20 PM" src="https://github.com/user-attachments/assets/b294cf6f-6def-4866-a1e3-ca2f2594570c" />
