### PR TITLE
CORE-1035 - new folio corn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `folio_new` to `corn`
+- Use `folio_new` in `algebra-1`
+
 ## [v2.11.0] - 2025-05-20
 
 - Add `borderless` table class to `webview`

--- a/styles/books/algebra-1/book.scss
+++ b/styles/books/algebra-1/book.scss
@@ -7,11 +7,12 @@ $PagesWithBands: (
 );
 
 $bandColor: #093D4C;
+$ChapterIntroType: fullWidth;
 
 @import 'framework/framework';
 @import '../../design-settings/corn/_design.scss';
 @import '../../design-settings/corn/_settings.scss';
-@import '../../designs/corn/pdf/folio';
+@import '../../designs/corn/pdf/folio_new';
 
 //Settings
 

--- a/styles/designs/corn/pdf/_folio_new.scss
+++ b/styles/designs/corn/pdf/_folio_new.scss
@@ -1,0 +1,198 @@
+// TODO: apply to all books and remove old file with folio
+
+@mixin folioStyles() {
+    font-size: font-scale(-1);
+    font-family: "Roboto Slab", serif;
+    color: #093D4C;
+    font-weight: 700;
+}
+
+@mixin parasWithBand($leftSelector, $rightSelector, $leftPosition, $rightPosition) {
+    #{$leftSelector} {
+        position: running(#{$leftPosition});
+        @include folioStyles();
+    }
+    
+    #{$leftSelector}::before { 
+        content: counter(page) "\00a0\00a0\00a0\00a0\00a0"; 
+    }
+    
+    #{$rightSelector} {
+        position: running(#{$rightPosition});
+        text-align: right;
+        @include folioStyles();
+    }
+    
+    #{$rightSelector}::after {
+        content: "\00a0\00a0\00a0\00a0\00a0" counter(page); 
+    }
+}
+
+// Paras
+p.folio-chapter {
+    position: running(folio_chapter);
+    @include folioStyles();
+}
+
+p.folio-module {
+    position: running(folio_module);
+    text-align: right;
+    @include folioStyles();
+}
+
+@include parasWithBand('p.folio-eoc-left', 'p.folio-eoc-right', folio_eoc_left, folio_eoc_right);
+@include parasWithBand('p.folio-appendix-left', 'p.folio-appendix-right', folio_appendix_left, folio_appendix_right);
+@include parasWithBand('p.folio-eob-left', 'p.folio-eob-right', folio_eob_left, folio_eob_right);
+
+
+//Page definitions
+nav#toc {
+    page: table-of-contents;
+}
+  
+div[data-type="page"].preface {
+    page: preface;
+    counter-reset: page 1;
+}
+
+.os-eoc {
+    page: eoc;
+}
+
+[data-type="chapter"] {
+    page: chapter;
+    prince-page-group: start;
+}
+
+div[data-type="page"].appendix {
+    page: appendix;
+}
+
+div[data-type="composite-page"].os-eob {
+    page: eob;
+}
+
+//Unnumbered pages
+@page chapter:first {
+    @top-left-corner {
+      content: none;
+    }
+    @top-right-corner {
+      content: none;
+    }
+    @top-left {
+      content: none;
+    }
+    @top-center {
+      content: none;
+    }
+    @top-right {
+      content: none;
+    }
+}
+
+@page table-of-contents {
+    @top-left-corner {
+      content: none;
+    }
+    @top-left {
+      content: none;
+    }
+    @top-right-corner {
+      content: none;
+    }
+    @top-right {
+      content: none;
+    }
+}
+
+@mixin folio($leftContent, $rightContent, $bottomContent, $page: null ) {
+    @page #{$page}:left {
+      @top-left {
+        content: $leftContent;
+        @include folioStyles();
+      }
+      @top-left-corner {
+        content: counter(page);
+        margin-right: h-spacing(5);
+        @include folioStyles();
+      }
+      @bottom-left {
+          content: $bottomContent;
+          @include folioStyles();
+      }
+    }
+  
+    @page #{$page}:right {
+      @top-right {
+        content: $rightContent;
+        @include folioStyles();
+      }
+      @top-right-corner {
+        content: counter(page);
+        margin-left: h-spacing(5);
+        @include folioStyles();
+      }
+    }
+}
+
+@mixin folioWithBand($leftContent, $rightContent, $bottomContent, $page) {
+    @page #{$page}:left {
+        @top-left {
+            content: $leftContent;
+            @include folioStyles();
+        }
+        @bottom-left {
+            content: $bottomContent;
+            @include folioStyles();
+        }
+    }
+  
+    @page #{$page}:right {
+        @top-right {
+            content: $rightContent;
+            @include folioStyles();
+        }
+    }
+}
+
+
+$defaultLeftContent: element(folio_chapter);
+$defaultRightContent: element(folio_module);
+
+$prefaceContent: string(preface-msg);
+$accessContent: string(access-for-free-msg);
+
+[data-pdf-folio-preface-message][data-pdf-folio-access-message] {
+  string-set: preface-msg attr(data-pdf-folio-preface-message) access-for-free-msg attr(data-pdf-folio-access-message); }
+
+$eocLeftContent: element(folio_eoc_left);
+$eocRightContent: element(folio_eoc_right);
+$appendixLeftContent: element(folio_appendix_left);
+$appendixRightContent: element(folio_appendix_right);
+$eobLeftContent: element(folio_eob_left);
+$eobRightContent: element(folio_eob_right);
+
+@include folio($defaultLeftContent, $defaultRightContent, $accessContent);
+@include folio($prefaceContent, $prefaceContent, $accessContent, preface );
+@include folioWithBand($eocLeftContent, $eocRightContent, $accessContent, eoc);
+@include folioWithBand($appendixLeftContent, $appendixRightContent, $accessContent, appendix);
+@include folioWithBand($eobLeftContent, $eobRightContent, $accessContent, eob);
+
+// Pages margins
+@page {
+  margin-left: 1in;
+  margin-right: 1in;
+  margin-bottom: 0.8in;
+  margin-top: 0.8in;
+}
+
+@if $ChapterIntroType == side {
+  @page chapter:first {
+    margin-right: 2in;
+  }
+  
+  @page chapter:nth(2) {
+    margin-right: 2in;
+  }
+}

--- a/styles/output/algebra-1-pdf.css
+++ b/styles/output/algebra-1-pdf.css
@@ -669,39 +669,96 @@ a {
   }
 }
 /* stylelint-disable-next-line meowtec/no-px */
-[data-type=chapter] > h1[data-type=document-title] .os-number {
-  string-set: chapter-number content();
-}
-[data-type=chapter] > h1[data-type=document-title] .os-text {
-  string-set: chapter-title content();
-}
-
-[data-type=chapter] > [data-type=page].introduction .intro-text > h2[data-type=document-title] {
-  string-set: module-number string(chapter-number);
-}
-[data-type=chapter] > [data-type=page].introduction .intro-text > h2[data-type=document-title] .os-text {
-  string-set: module-title content();
-}
-[data-type=chapter] > [data-type=page]:not(.introduction) > h2[data-type=document-title] .os-number {
-  string-set: module-number content();
-}
-[data-type=chapter] > [data-type=page]:not(.introduction) > h2[data-type=document-title] .os-text {
-  string-set: module-title content();
+p.folio-chapter {
+  position: running(folio_chapter);
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
 }
 
-.os-eoc > h2[data-type=document-title] .os-text {
-  string-set: eoc-title content();
+p.folio-module {
+  position: running(folio_module);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
 }
 
-.appendix > h1[data-type=document-title] .os-number {
-  string-set: appendix-number content();
-}
-.appendix > h1[data-type=document-title] .os-text {
-  string-set: appendix-title content();
+p.folio-eoc-left {
+  position: running(folio_eoc_left);
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
 }
 
-div.os-eob > h1[data-type=document-title] .os-text {
-  string-set: eob-title content();
+p.folio-eoc-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-eoc-right {
+  position: running(folio_eoc_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
+}
+
+p.folio-eoc-right::after {
+  content: "     " counter(page);
+}
+
+p.folio-appendix-left {
+  position: running(folio_appendix_left);
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
+}
+
+p.folio-appendix-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-appendix-right {
+  position: running(folio_appendix_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
+}
+
+p.folio-appendix-right::after {
+  content: "     " counter(page);
+}
+
+p.folio-eob-left {
+  position: running(folio_eob_left);
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
+}
+
+p.folio-eob-left::before {
+  content: counter(page) "     ";
+}
+
+p.folio-eob-right {
+  position: running(folio_eob_right);
+  text-align: right;
+  font-size: 0.8333333333rem;
+  font-family: "Roboto Slab", serif;
+  color: #093D4C;
+  font-weight: 700;
+}
+
+p.folio-eob-right::after {
+  content: "     " counter(page);
 }
 
 nav#toc {
@@ -730,6 +787,23 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
+@page chapter:first {
+  @top-left-corner {
+    content: none;
+  }
+  @top-right-corner {
+    content: none;
+  }
+  @top-left {
+    content: none;
+  }
+  @top-center {
+    content: none;
+  }
+  @top-right {
+    content: none;
+  }
+}
 @page table-of-contents {
   @top-left-corner {
     content: none;
@@ -744,207 +818,165 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
-  @top-right-corner {
-    font-size: 0.8333333333rem;
-    font-family: "Roboto Slab", serif;
-    color: white;
-    background: #093D4C;
-    margin-right: -1.2rem;
-    margin-top: -1.2rem;
-    padding-right: 2.4rem;
-    padding-top: 2.4rem;
-    height: 0.95in;
-    width: 1.15in;
-    z-index: -1;
-    content: "     " counter(page);
-  }
-  @top-middle {
-    background: #093D4C;
-    padding-top: 2.4rem;
-    margin-top: -1.2rem;
-    height: 0.95in;
-    z-index: -1;
-    content: " ";
-  }
-  @top-right {
-    font-size: 0.8333333333rem;
-    font-family: "Roboto Slab", serif;
-    color: white;
-    background: #093D4C;
-    height: 0.95in;
-    padding-top: 2.4rem;
-    margin-top: -1.2rem;
-    z-index: -1;
-    content: string(module-number) " • " string(module-title) "     ";
-  }
-  @top-left-corner {
-    background: #093D4C;
-    width: 1.15in;
-    height: 0.95in;
-    margin-left: -1.2rem;
-    padding-left: 2.4rem;
-    padding-top: 2.4rem;
-    margin-top: -1.2rem;
-    z-index: -1;
-    content: " ";
-  }
-}
 [data-pdf-folio-preface-message][data-pdf-folio-access-message] {
   string-set: preface-msg attr(data-pdf-folio-preface-message) access-for-free-msg attr(data-pdf-folio-access-message);
 }
 
 @page :left {
   @top-left {
+    content: element(folio_chapter);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(chapter-number) " • " string(chapter-title);
   }
   @top-left-corner {
+    content: counter(page);
+    margin-right: 40px;
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: counter(page) "     ";
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page :right {
   @top-right {
+    content: element(folio_module);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(module-number) " • " string(module-title);
   }
   @top-right-corner {
+    content: counter(page);
+    margin-left: 40px;
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: "     " counter(page);
   }
 }
 @page preface:left {
   @top-left {
+    content: string(preface-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(preface-msg);
   }
   @top-left-corner {
+    content: counter(page);
+    margin-right: 40px;
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: counter(page) "     ";
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page preface:right {
   @top-right {
+    content: string(preface-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(preface-msg);
   }
   @top-right-corner {
+    content: counter(page);
+    margin-left: 40px;
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: "     " counter(page);
   }
 }
 @page eoc:left {
   @top-left {
+    content: element(folio_eoc_left);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: counter(page) "     " string(chapter-number) " • " string(eoc-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page eoc:right {
   @top-right {
+    content: element(folio_eoc_right);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(chapter-number) " • " string(eoc-title) "     " counter(page);
   }
 }
 @page appendix:left {
   @top-left {
+    content: element(folio_appendix_left);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: counter(page) "     " string(appendix-number) " • " string(appendix-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page appendix:right {
   @top-right {
+    content: element(folio_appendix_right);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(appendix-number) " • " string(appendix-title) "     " counter(page);
   }
 }
 @page eob:left {
   @top-left {
+    content: element(folio_eob_left);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: counter(page) "     " string(eob-title);
   }
   @bottom-left {
+    content: string(access-for-free-msg);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(access-for-free-msg);
   }
 }
 @page eob:right {
   @top-right {
+    content: element(folio_eob_right);
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
     color: #093D4C;
     font-weight: 700;
-    content: string(eob-title) "     " counter(page);
   }
 }
 @page {


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1035

Related to https://github.com/openstax/cookbook/pull/413

Enables the new folio design which uses content generated by cookbook instead of content generated in the css.

Some examples:

## With number
<img width="353" alt="Screenshot 2025-06-18 at 4 48 27 PM" src="https://github.com/user-attachments/assets/67913be3-1c01-4f15-a991-9f90a2a03259" />

## Without number
<img width="353" alt="Screenshot 2025-06-18 at 4 50 00 PM" src="https://github.com/user-attachments/assets/cddb849f-a025-481f-8999-6e064eac93e6" />

In the old version, that dot that is normally in between the number and the title would be there even if there were not a number.
