### PR TITLE
Small fix to avoid breaks after example titles in algebra-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [v2.12.1] - 2025-08-26
+
+- Avoid breaks after `example-title` in `algebra-1`
+
 ## [v2.12.0] - 2025-08-25
 
 - Add `UnitToc` to `corn`

--- a/styles/books/algebra-1/book.scss
+++ b/styles/books/algebra-1/book.scss
@@ -515,6 +515,7 @@ section.numbered-exercises [data-type=exercise] img {
       border-bottom-width: null,
       border-bottom-style: null,
       border-bottom-color: null,
+      break-after: avoid,
     ),
     ExampleTitle: (
       font-family: (_ref: 'typography:::baseFont'),

--- a/styles/designs/corn/parts/_example-components.scss
+++ b/styles/designs/corn/parts/_example-components.scss
@@ -11,6 +11,7 @@ $Example__Container: (
         margin-bottom: v-spacing(2),
         display: block,
         box-decoration-break: slice,
+        break-after: enum('ValueSet:::OPTIONAL'), // used in algebra-1
     )
 );
 

--- a/styles/output/algebra-1-pdf.css
+++ b/styles/output/algebra-1-pdf.css
@@ -1460,6 +1460,7 @@ p.example-title {
   margin-bottom: 1.4rem;
   display: block;
   box-decoration-break: slice;
+  break-after: avoid;
 }
 
 p.example-title > :first-child {


### PR DESCRIPTION
Small fix for example titles so that they should appear on the same page as the example body.

<img width="1700" height="2200" alt="128" src="https://github.com/user-attachments/assets/80a82754-9c19-4af5-8f6d-6929656ea4d7" />
<img width="1700" height="2200" alt="129" src="https://github.com/user-attachments/assets/fb8ccc02-a6fe-4f07-8fb0-5332474518d9" />
