### PR TITLE
Release v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.18.0] - 2026-04-07
+
 - Fix wide SVG equations overlapping equation numbers in `corn` by making number a flex sibling instead of absolutely positioned
 - Improve color contrast on titles in `corn`
 - Fix folio text color contrast on unit opener pages in `marketing` (white text on dark blue background)


### PR DESCRIPTION
## Summary

Release a new minor version of openstax/ce-styles that includes the latest changes from the unreleased section.

## Changes Included

- Fix wide SVG equations overlapping equation numbers in `corn` by making number a flex sibling instead of absolutely positioned
- Improve color contrast on titles in `corn`
- Fix folio text color contrast on unit opener pages in `marketing` (white text on dark blue background)
- Fix link contrast on unit opener pages in `marketing` by updating `unitOpenerBackgroundLightColor` to white
- Use `-prince-expansion-text` to replace screenreader spans
- Exclude bare links from `ReferencesLink` in `cardboard`
- Fix link contrast in `FigureSplashShape` in `carnival`
- Fix wide MathML SVGs in answer key overflowing past page banding in `corn` by adding `table-layout: fixed` and `max-width: 100%` to solution areas

## Related

- Jira ticket: https://openstax.atlassian.net/browse/CORE-1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)