### PR TITLE
Add PrinceXML 16 compatibility fixes to common PDF styles: reset list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add PrinceXML 16 compatibility fixes to common PDF styles: reset `ol`/`ul` margin/padding and set `box-decoration-break: clone` globally
+- Update key terms PDF tag structure in `cardboard`, `carnival`, `cosmos`, and `corn` to match new `BakeChapterGlossary::V1` HTML output: add `KeyTermsListContainer` (`L`) and `KeyTermsListItem` (`LI`) components targeting `.os-glossary-list` and `.os-glossary-list-item` wrappers, and retag `KeyTermsList`/`KeyTermsTerm`/`KeyTermsDefinition` as `LBody`/`Span`/`Span`
+
 ## [v2.18.0] - 2026-04-07
 
 - Fix wide SVG equations overlapping equation numbers in `corn` by making number a flex sibling instead of absolutely positioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [v2.19.0] - 2026-04-15
+
 - Add PrinceXML 16 compatibility fixes to common PDF styles: reset `ol`/`ul` margin/padding and set `box-decoration-break: clone` globally
 - Update key terms PDF tag structure in `cardboard`, `carnival`, `cosmos`, and `corn` to match new `BakeChapterGlossary::V1` HTML output: add `KeyTermsListContainer` (`L`) and `KeyTermsListItem` (`LI`) components targeting `.os-glossary-list` and `.os-glossary-list-item` wrappers, and retag `KeyTermsList`/`KeyTermsTerm`/`KeyTermsDefinition` as `LBody`/`Span`/`Span`
 - Use `nth-of-group` instead of `nth` (PrinceXML 16 breaking change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add PrinceXML 16 compatibility fixes to common PDF styles: reset `ol`/`ul` margin/padding and set `box-decoration-break: clone` globally
 - Update key terms PDF tag structure in `cardboard`, `carnival`, `cosmos`, and `corn` to match new `BakeChapterGlossary::V1` HTML output: add `KeyTermsListContainer` (`L`) and `KeyTermsListItem` (`LI`) components targeting `.os-glossary-list` and `.os-glossary-list-item` wrappers, and retag `KeyTermsList`/`KeyTermsTerm`/`KeyTermsDefinition` as `LBody`/`Span`/`Span`
+- Use `nth-of-group` instead of `nth` (PrinceXML 16 breaking change)
 
 ## [v2.18.0] - 2026-04-07
 

--- a/styles/designs/cardboard/parts/_keyterms-components.scss
+++ b/styles/designs/cardboard/parts/_keyterms-components.scss
@@ -3,8 +3,23 @@ $KeyTerms__Container: (
     _subselector: "",
     _properties: (
         margin-bottom: v-spacing(2),
-        -prince-pdf-tag-type: L,
     ),
+);
+
+$KeyTerms__ListContainer:(
+    _name: "KeyTermsListContainer",
+    _subselector: " > .os-glossary-list",
+    _properties:(
+        -prince-pdf-tag-type: L,
+    )
+);
+
+$KeyTerms__ListItem:(
+    _name: "KeyTermsListItem",
+    _subselector: " > .os-glossary-list-item",
+    _properties:(
+        -prince-pdf-tag-type: LI,
+    )
 );
 
 $KeyTerms__List:(
@@ -13,7 +28,7 @@ $KeyTerms__List:(
     _properties:(
         text-indent: h-spacing(-2),
         padding-left: h-spacing(2),
-        -prince-pdf-tag-type: LI,
+        -prince-pdf-tag-type: LBody,
     ),
 );
 
@@ -24,7 +39,7 @@ $KeyTerms__Term:(
         font-weight: bold,
         padding-right: h-spacing(1),
         display: inline,
-        -prince-pdf-tag-type: Lbl,
+        -prince-pdf-tag-type: Span,
     )
 );
 
@@ -34,6 +49,6 @@ $KeyTerms__Definition:(
     _properties:(
         display: inline,
         margin-left: h-spacing(0),
-        -prince-pdf-tag-type: LBody,
+        -prince-pdf-tag-type: Span,
     )
 );

--- a/styles/designs/cardboard/parts/_keyterms-shapes.scss
+++ b/styles/designs/cardboard/parts/_keyterms-shapes.scss
@@ -4,11 +4,19 @@
     _components:(
         map-merge($KeyTerms__Container,(
             _components:(
-                map-merge($KeyTerms__List,(
+                map-merge($KeyTerms__ListContainer, (
                     _components:(
-                        $KeyTerms__Term,
-                        $KeyTerms__Definition,
-                    ),
+                        map-merge($KeyTerms__ListItem, (
+                            _components: (
+                                map-merge($KeyTerms__List,(
+                                    _components:(
+                                        $KeyTerms__Term,
+                                        $KeyTerms__Definition,
+                                    ),
+                                )),
+                            )
+                        )),
+                    )
                 )),
             ),
         )),

--- a/styles/designs/cardboard/pdf/_folio.scss
+++ b/styles/designs/cardboard/pdf/_folio.scss
@@ -97,7 +97,7 @@ div[data-type="composite-page"].os-eob {
 
 //Chapter Intro
   
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }

--- a/styles/designs/cardboard/pdf/locale/pl/_folio.scss
+++ b/styles/designs/cardboard/pdf/locale/pl/_folio.scss
@@ -93,7 +93,7 @@
   
   //Chapter Intro
   
-  @page chapter:nth(1):right {
+  @page chapter:nth-of-group(1):right {
     @top-right-corner {
       content: none;
     }

--- a/styles/designs/carnival/parts/_keyterms-components.scss
+++ b/styles/designs/carnival/parts/_keyterms-components.scss
@@ -1,9 +1,19 @@
-$KeyTerms__Container: (
-    _name: "KeyTermsContainer",
-    _subselector: "",
-    _properties: (
+$KeyTerms__Container: empty_wrapper(KeyTermsContainer, '');
+
+$KeyTerms__ListContainer:(
+    _name: "KeyTermsListContainer",
+    _subselector: " > .os-glossary-list",
+    _properties:(
         -prince-pdf-tag-type: L,
-    ),
+    )
+);
+
+$KeyTerms__ListItem:(
+    _name: "KeyTermsListItem",
+    _subselector: " > .os-glossary-list-item",
+    _properties:(
+        -prince-pdf-tag-type: LI,
+    )
 );
 
 $KeyTerms__List:(
@@ -12,7 +22,7 @@ $KeyTerms__List:(
     _properties:(
         text-indent: h-spacing(-2),
         padding-left: h-spacing(2),
-        -prince-pdf-tag-type: LI,
+        -prince-pdf-tag-type: LBody,
     ),
 );
 
@@ -23,7 +33,7 @@ $KeyTerms__Term:(
         font-weight: bold,
         padding-right: h-spacing(1),
         display: inline,
-        -prince-pdf-tag-type: Lbl,
+        -prince-pdf-tag-type: Span,
     )
 );
 
@@ -33,6 +43,6 @@ $KeyTerms__Definition:(
     _properties:(
         display: inline,
         margin-left: h-spacing(0),
-        -prince-pdf-tag-type: LBody,
+        -prince-pdf-tag-type: Span,
     )
 );

--- a/styles/designs/carnival/parts/_keyterms-shapes.scss
+++ b/styles/designs/carnival/parts/_keyterms-shapes.scss
@@ -4,11 +4,19 @@
     _components:(
         map-merge($KeyTerms__Container,(
             _components:(
-                map-merge($KeyTerms__List,(
+                map-merge($KeyTerms__ListContainer, (
                     _components:(
-                        $KeyTerms__Term,
-                        $KeyTerms__Definition,
-                    ),
+                        map-merge($KeyTerms__ListItem, (
+                            _components: (
+                                map-merge($KeyTerms__List,(
+                                    _components:(
+                                        $KeyTerms__Term,
+                                        $KeyTerms__Definition,
+                                    ),
+                                )),
+                            )
+                        )),
+                    )
                 )),
             ),
         )),

--- a/styles/designs/carnival/pdf/_folio.scss
+++ b/styles/designs/carnival/pdf/_folio.scss
@@ -82,7 +82,7 @@ div[data-type="composite-page"].os-eob {
 
 
 //Unnumbered pages
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -205,7 +205,7 @@ $eobContent: string(eob-title);
     margin-right: 2in;
   }
   
-  @page chapter:nth(2) {
+  @page chapter:nth-of-group(2) {
     margin-right: 2in;
   }
 }

--- a/styles/designs/carnival/pdf/_folio_new.scss
+++ b/styles/designs/carnival/pdf/_folio_new.scss
@@ -192,7 +192,7 @@ $eobRightContent: element(folio_eob_right);
     margin-right: 2in;
   }
   
-  @page chapter:nth(2) {
+  @page chapter:nth-of-group(2) {
     margin-right: 2in;
   }
 }

--- a/styles/designs/carnival/pdf/locale/pl/_folio.scss
+++ b/styles/designs/carnival/pdf/locale/pl/_folio.scss
@@ -82,7 +82,7 @@
   
   
   //Unnumbered pages
-  @page chapter:nth(1) {
+  @page chapter:nth-of-group(1) {
     @top-left-corner {
       content: none;
     }
@@ -205,7 +205,7 @@
       margin-right: 2in;
     }
     
-    @page chapter:nth(2) {
+    @page chapter:nth-of-group(2) {
       margin-right: 2in;
     }
   }

--- a/styles/designs/common/pdf/_common-styles.scss
+++ b/styles/designs/common/pdf/_common-styles.scss
@@ -1,3 +1,6 @@
+ol, ul { margin-left: 1.5em; padding-left: 0; }
+* { box-decoration-break: clone; }
+
 a[href^="http"]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;

--- a/styles/designs/corn/parts/_keyterms-components.scss
+++ b/styles/designs/corn/parts/_keyterms-components.scss
@@ -1,9 +1,19 @@
-$KeyTerms__Container: (
-    _name: "KeyTermsContainer",
-    _subselector: "",
-    _properties: (
+$KeyTerms__Container: empty_wrapper(KeyTermsContainer, '');
+
+$KeyTerms__ListContainer:(
+    _name: "KeyTermsListContainer",
+    _subselector: " > .os-glossary-list",
+    _properties:(
         -prince-pdf-tag-type: L,
-    ),
+    )
+);
+
+$KeyTerms__ListItem:(
+    _name: "KeyTermsListItem",
+    _subselector: " > .os-glossary-list-item",
+    _properties:(
+        -prince-pdf-tag-type: LI,
+    )
 );
 
 $KeyTerms__List:(
@@ -12,7 +22,7 @@ $KeyTerms__List:(
     _properties:(
         text-indent: h-spacing(-2),
         padding-left: h-spacing(2),
-        -prince-pdf-tag-type: LI,
+        -prince-pdf-tag-type: LBody,
     ),
 );
 
@@ -23,7 +33,7 @@ $KeyTerms__Term:(
         font-weight: bold,
         padding-right: h-spacing(1),
         display: inline,
-        -prince-pdf-tag-type: Lbl,
+        -prince-pdf-tag-type: Span,
     )
 );
 
@@ -33,6 +43,6 @@ $KeyTerms__Definition:(
     _properties:(
         display: inline,
         margin-left: h-spacing(0),
-        -prince-pdf-tag-type: LBody,
+        -prince-pdf-tag-type: Span,
     )
 );

--- a/styles/designs/corn/parts/_keyterms-shapes.scss
+++ b/styles/designs/corn/parts/_keyterms-shapes.scss
@@ -5,16 +5,24 @@
     _components:(
         map-merge($KeyTerms__Container,(
             _components:(
-                map-merge($KeyTerms__List,(
+                map-merge($KeyTerms__ListContainer, (
                     _components:(
-                        $KeyTerms__Term,
-                        map-merge($KeyTerms__Definition, (
+                        map-merge($KeyTerms__ListItem, (
                             _components: (
-                                $UnorderedList--KeyTerms,
-                                $OrderedList--KeyTerms,
-                            ),
-                        ))
-                    ),
+                                map-merge($KeyTerms__List,(
+                                    _components:(
+                                        $KeyTerms__Term,
+                                        map-merge($KeyTerms__Definition, (
+                                            _components: (
+                                                $UnorderedList--KeyTerms,
+                                                $OrderedList--KeyTerms,
+                                            ),
+                                        )),
+                                    ),
+                                )),
+                            )
+                        )),
+                    )
                 )),
             ),
         )),

--- a/styles/designs/corn/pdf/_folio.scss
+++ b/styles/designs/corn/pdf/_folio.scss
@@ -95,7 +95,7 @@ div[data-type="composite-page"].os-eob {
 
 //Chapter Intro Top Bar
 
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: font-scale(-1);
     font-family: "Roboto Slab", serif;

--- a/styles/designs/corn/pdf/_folio_new.scss
+++ b/styles/designs/corn/pdf/_folio_new.scss
@@ -192,7 +192,7 @@ $eobRightContent: element(folio_eob_right);
     margin-right: 2in;
   }
   
-  @page chapter:nth(2) {
+  @page chapter:nth-of-group(2) {
     margin-right: 2in;
   }
 }

--- a/styles/designs/corn/pdf/locale/pl/_folio.scss
+++ b/styles/designs/corn/pdf/locale/pl/_folio.scss
@@ -95,7 +95,7 @@ div[data-type="composite-page"].os-eob {
 
 //Chapter Intro Top Bar
 
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: font-scale(-1);
     font-family: "Roboto Slab", serif;

--- a/styles/designs/cosmos/parts/_keyterms-components.scss
+++ b/styles/designs/cosmos/parts/_keyterms-components.scss
@@ -1,9 +1,19 @@
-$KeyTerms__Container: (
-    _name: "KeyTermsContainer",
-    _subselector: "",
-    _properties: (
+$KeyTerms__Container: empty_wrapper(KeyTermsContainer, '');
+
+$KeyTerms__ListContainer:(
+    _name: "KeyTermsListContainer",
+    _subselector: " > .os-glossary-list",
+    _properties:(
         -prince-pdf-tag-type: L,
-    ),
+    )
+);
+
+$KeyTerms__ListItem:(
+    _name: "KeyTermsListItem",
+    _subselector: " > .os-glossary-list-item",
+    _properties:(
+        -prince-pdf-tag-type: LI,
+    )
 );
 
 $KeyTerms__List:(
@@ -12,7 +22,7 @@ $KeyTerms__List:(
     _properties:(
         text-indent: h-spacing(-3),
         padding-left: h-spacing(3),
-        -prince-pdf-tag-type: LI,
+        -prince-pdf-tag-type: LBody,
     ),
 );
 
@@ -22,7 +32,7 @@ $KeyTerms__Term:(
     _properties:(
         display: inline,
         font-weight: bold,
-        -prince-pdf-tag-type: Lbl,
+        -prince-pdf-tag-type: Span,
     )
 );
 
@@ -32,6 +42,6 @@ $KeyTerms__Definition:(
     _properties:(
         display: inline,
         margin-left: 2px,
-        -prince-pdf-tag-type: LBody,
+        -prince-pdf-tag-type: Span,
     )
 );

--- a/styles/designs/cosmos/parts/_keyterms-shapes.scss
+++ b/styles/designs/cosmos/parts/_keyterms-shapes.scss
@@ -4,11 +4,19 @@
     _components:(
         map-merge($KeyTerms__Container,(
             _components:(
-                map-merge($KeyTerms__List,(
+                map-merge($KeyTerms__ListContainer, (
                     _components:(
-                        $KeyTerms__Term,
-                        $KeyTerms__Definition,
-                    ),
+                        map-merge($KeyTerms__ListItem, (
+                            _components: (
+                                map-merge($KeyTerms__List,(
+                                    _components:(
+                                        $KeyTerms__Term,
+                                        $KeyTerms__Definition,
+                                    ),
+                                )),
+                            )
+                        )),
+                    )
                 )),
             ),
         )),

--- a/styles/designs/cosmos/pdf/_folio.scss
+++ b/styles/designs/cosmos/pdf/_folio.scss
@@ -112,7 +112,7 @@
     }
   }
 
-  @page chapter:nth(1) {
+  @page chapter:nth-of-group(1) {
     @top-left-corner {
     content: none;
     }

--- a/styles/designs/cosmos/pdf/locale/pl/_folio.scss
+++ b/styles/designs/cosmos/pdf/locale/pl/_folio.scss
@@ -76,7 +76,7 @@
   
   //Unnumbered Pages
 
-  @page chapter:nth(1) {
+  @page chapter:nth-of-group(1) {
     @top-left-corner {
     content: none;
     }

--- a/styles/output/accounting-pdf.css
+++ b/styles/output/accounting-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -4709,26 +4718,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/additive-manufacturing-pdf.css
+++ b/styles/output/additive-manufacturing-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -3181,35 +3190,39 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/algebra-1-pdf.css
+++ b/styles/output/algebra-1-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -3808,35 +3817,39 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/american-government-pdf.css
+++ b/styles/output/american-government-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -761,7 +770,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2772,26 +2781,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-top: 1rem;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-suggested-reading-container p {

--- a/styles/output/anatomy-pdf.css
+++ b/styles/output/anatomy-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -619,7 +628,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2731,27 +2740,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 0;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-interactive-exercise-container [data-type=exercise] {

--- a/styles/output/anthropology-pdf.css
+++ b/styles/output/anthropology-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -619,7 +628,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2981,27 +2990,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-right: 8px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-critical-thinking-container [data-type=exercise] {

--- a/styles/output/ap-biology-pdf.css
+++ b/styles/output/ap-biology-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -937,7 +946,7 @@ div[data-type=composite-page].os-eob {
 @page chapter:first {
   margin-right: 2in;
 }
-@page chapter:nth(2) {
+@page chapter:nth-of-group(2) {
   margin-right: 2in;
 }
 :root {
@@ -1558,27 +1567,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-top: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-visual-exercise-container [data-type=exercise] {

--- a/styles/output/ap-physics-2e-pdf.css
+++ b/styles/output/ap-physics-2e-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1831,27 +1840,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-right: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-conceptual-questions-container [data-type=exercise] {

--- a/styles/output/ap-physics-pdf.css
+++ b/styles/output/ap-physics-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1831,27 +1840,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-right: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-conceptual-questions-container [data-type=exercise] {

--- a/styles/output/astronomy-pdf.css
+++ b/styles/output/astronomy-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -745,7 +754,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3302,26 +3311,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-further-exploration-container > p {

--- a/styles/output/bca-pdf.css
+++ b/styles/output/bca-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3639,26 +3648,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-references-container > section.references {

--- a/styles/output/biology-pdf.css
+++ b/styles/output/biology-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -937,7 +946,7 @@ div[data-type=composite-page].os-eob {
 @page chapter:first {
   margin-right: 2in;
 }
-@page chapter:nth(2) {
+@page chapter:nth-of-group(2) {
   margin-right: 2in;
 }
 :root {
@@ -1558,27 +1567,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-top: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-visual-exercise-container [data-type=exercise] {

--- a/styles/output/business-ethics-pdf.css
+++ b/styles/output/business-ethics-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3504,26 +3513,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-references-container > section.references {

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -3350,35 +3359,39 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-align: center;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/chemistry-pdf.css
+++ b/styles/output/chemistry-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1547,27 +1556,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-top: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-key-equations-container > section > .os-table.os-unstyled-container {

--- a/styles/output/college-physics-2e-pdf.css
+++ b/styles/output/college-physics-2e-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1831,27 +1840,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-right: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-conceptual-questions-container [data-type=exercise] {

--- a/styles/output/college-physics-pdf.css
+++ b/styles/output/college-physics-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1831,27 +1840,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-right: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=chapter] > .os-conceptual-questions-container [data-type=exercise] {

--- a/styles/output/college-success-pdf.css
+++ b/styles/output/college-success-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -745,7 +754,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }

--- a/styles/output/computer-science-pdf.css
+++ b/styles/output/computer-science-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -4500,26 +4509,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/contemporary-math-pdf.css
+++ b/styles/output/contemporary-math-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -3433,35 +3442,39 @@ li > table {
   padding-top: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/data-science-pdf.css
+++ b/styles/output/data-science-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3666,26 +3675,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-chapter-review-container [data-type=exercise] {

--- a/styles/output/dev-math-pdf.css
+++ b/styles/output/dev-math-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -4506,35 +4515,39 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/economics-pdf.css
+++ b/styles/output/economics-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -761,7 +770,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2623,26 +2632,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/english-composition-pdf.css
+++ b/styles/output/english-composition-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -644,7 +653,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }

--- a/styles/output/entrepreneurship-pdf.css
+++ b/styles/output/entrepreneurship-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -745,7 +754,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3710,26 +3719,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-suggested-resources-container > p {

--- a/styles/output/finance-pdf.css
+++ b/styles/output/finance-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -4210,26 +4219,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/history-pdf.css
+++ b/styles/output/history-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -761,7 +770,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2467,26 +2476,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-right: 8px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/hs-college-success-pdf.css
+++ b/styles/output/hs-college-success-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -745,7 +754,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }

--- a/styles/output/hs-physics-pdf.css
+++ b/styles/output/hs-physics-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1882,27 +1891,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-top: 1rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 [data-type=page] :not(.os-note-body) [data-type=exercise] {

--- a/styles/output/information-systems-pdf.css
+++ b/styles/output/information-systems-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -2830,26 +2839,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-review-questions-container [data-type=exercise] {

--- a/styles/output/intro-business-pdf.css
+++ b/styles/output/intro-business-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -745,7 +754,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -3573,26 +3582,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/lifespan-development-pdf.css
+++ b/styles/output/lifespan-development-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -761,7 +770,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2616,26 +2625,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 0;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/marketing-pdf.css
+++ b/styles/output/marketing-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -746,7 +755,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -5007,26 +5016,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-references-container > section.references {

--- a/styles/output/microbiology-pdf.css
+++ b/styles/output/microbiology-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }

--- a/styles/output/neuroscience-pdf.css
+++ b/styles/output/neuroscience-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -937,7 +946,7 @@ div[data-type=composite-page].os-eob {
 @page chapter:first {
   margin-right: 2in;
 }
-@page chapter:nth(2) {
+@page chapter:nth-of-group(2) {
   margin-right: 2in;
 }
 :root {
@@ -3279,27 +3288,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 0;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-section-summary-container {

--- a/styles/output/nursing-external-pdf.css
+++ b/styles/output/nursing-external-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -4409,27 +4418,31 @@ a[role=doc-noteref] {
   font-weight: 500;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-review-questions-container [data-type=exercise] {

--- a/styles/output/nursing-internal-pdf.css
+++ b/styles/output/nursing-internal-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -4208,27 +4217,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   display: inline;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-review-questions-container [data-type=exercise], .os-check-understanding-container [data-type=exercise], .os-critical-thinking-container [data-type=exercise], .os-competency-based-container [data-type=exercise], .os-reflection-questions-container [data-type=exercise], .os-what-nurses-do-container [data-type=exercise] {

--- a/styles/output/organic-chemistry-pdf.css
+++ b/styles/output/organic-chemistry-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;

--- a/styles/output/philosophy-pdf.css
+++ b/styles/output/philosophy-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -644,7 +653,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2559,26 +2568,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-left: 16px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-review-questions-container [data-type=exercise] {

--- a/styles/output/pl-economics-pdf.css
+++ b/styles/output/pl-economics-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -728,7 +737,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2903,26 +2912,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/pl-marketing-pdf.css
+++ b/styles/output/pl-marketing-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -742,7 +751,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -4133,26 +4142,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/pl-nursing-pdf.css
+++ b/styles/output/pl-nursing-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -3535,27 +3544,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-bottom: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-review-questions-container [data-type=exercise] {

--- a/styles/output/pl-psychology-pdf.css
+++ b/styles/output/pl-psychology-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -611,7 +620,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2359,26 +2368,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-top: 1rem;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/pl-u-physics-pdf.css
+++ b/styles/output/pl-u-physics-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1992,27 +2001,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-key-equations-container > section > .os-table.os-unstyled-container {

--- a/styles/output/political-science-pdf.css
+++ b/styles/output/political-science-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -644,7 +653,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2666,26 +2675,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-bottom: 1.4rem;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc.os-suggested-readings-container p {

--- a/styles/output/precalculus-coreq-pdf.css
+++ b/styles/output/precalculus-coreq-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -635,7 +644,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -4135,35 +4144,39 @@ section.coreq-skills [data-type=injected-exercise][data-is-multipart=True] > [da
   margin-left: 16px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/precalculus-pdf.css
+++ b/styles/output/precalculus-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -3918,35 +3927,39 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 16px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/principles-management-pdf.css
+++ b/styles/output/principles-management-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -628,7 +637,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }
@@ -2905,26 +2914,33 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
 
 .os-glossary-container {
   margin-bottom: 1.4rem;
+}
+
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/psychology-pdf.css
+++ b/styles/output/psychology-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -644,7 +653,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2414,26 +2423,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-top: 1rem;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/python-pdf.css
+++ b/styles/output/python-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -512,7 +521,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     content: none;
   }

--- a/styles/output/sociology-pdf.css
+++ b/styles/output/sociology-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -644,7 +653,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2591,26 +2600,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   padding-left: 16px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {

--- a/styles/output/statistics-pdf.css
+++ b/styles/output/statistics-pdf.css
@@ -243,6 +243,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -752,7 +761,7 @@ div[data-type=composite-page].os-eob {
     content: none;
   }
 }
-@page chapter:nth(1):right {
+@page chapter:nth-of-group(1):right {
   @top-right-corner {
     font-size: 0.8333333333rem;
     font-family: "Roboto Slab", serif;
@@ -4239,35 +4248,39 @@ p > [data-type=title] {
   padding-left: 0.7rem;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
-  font-weight: bold;
-  padding-right: 8px;
-  display: inline;
-  -prince-pdf-tag-type: Lbl;
-}
-
-.os-glossary-container > dl > dd {
-  display: inline;
-  margin-left: 0px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
   -prince-pdf-tag-type: LBody;
 }
 
-.os-glossary-container > dl > dd > ul {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
+  display: inline;
+  margin-left: 0px;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ul {
   margin-left: 16px;
   text-indent: 0;
 }
 
-.os-glossary-container > dl > dd > ol {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd > ol {
   margin-left: 16px;
   text-indent: 0;
 }

--- a/styles/output/u-physics-pdf.css
+++ b/styles/output/u-physics-pdf.css
@@ -234,6 +234,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -736,7 +745,7 @@ div[data-type=composite-page].os-eob {
   page: eob;
 }
 
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -1983,27 +1992,31 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 8px;
 }
 
-.os-glossary-container {
+.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-glossary-container > dl {
-  text-indent: -16px;
-  padding-left: 16px;
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-glossary-container > dl > dt {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -16px;
+  padding-left: 16px;
+  -prince-pdf-tag-type: LBody;
+}
+
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
   font-weight: bold;
   padding-right: 8px;
   display: inline;
-  -prince-pdf-tag-type: Lbl;
+  -prince-pdf-tag-type: Span;
 }
 
-.os-glossary-container > dl > dd {
+.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 0px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-key-equations-container > section > .os-table.os-unstyled-container {

--- a/styles/output/world-history-pdf.css
+++ b/styles/output/world-history-pdf.css
@@ -233,6 +233,15 @@ blockquote {
 }
 
 /* stylelint-disable-next-line meowtec/no-px */
+ol, ul {
+  margin-left: 1.5em;
+  padding-left: 0;
+}
+
+* {
+  box-decoration-break: clone;
+}
+
 a[href^=http]:not([data-bare-link])::after {
   content: " (" attr(href) ")";
   overflow-wrap: break-word;
@@ -761,7 +770,7 @@ div[data-type=page].handbook {
     content: none;
   }
 }
-@page chapter:nth(1) {
+@page chapter:nth-of-group(1) {
   @top-left-corner {
     content: none;
   }
@@ -2715,26 +2724,30 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   margin-left: 24px;
 }
 
-.os-eoc.os-glossary-container {
+.os-eoc.os-glossary-container > .os-glossary-list {
   -prince-pdf-tag-type: L;
 }
 
-.os-eoc.os-glossary-container > dl {
-  text-indent: -24px;
-  padding-left: 24px;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item {
   -prince-pdf-tag-type: LI;
 }
 
-.os-eoc.os-glossary-container > dl > dt {
-  display: inline;
-  font-weight: bold;
-  -prince-pdf-tag-type: Lbl;
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl {
+  text-indent: -24px;
+  padding-left: 24px;
+  -prince-pdf-tag-type: LBody;
 }
 
-.os-eoc.os-glossary-container > dl > dd {
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dt {
+  display: inline;
+  font-weight: bold;
+  -prince-pdf-tag-type: Span;
+}
+
+.os-eoc.os-glossary-container > .os-glossary-list > .os-glossary-list-item > dl > dd {
   display: inline;
   margin-left: 2px;
-  -prince-pdf-tag-type: LBody;
+  -prince-pdf-tag-type: Span;
 }
 
 .os-eoc[data-type=composite-page] {


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1784

# Explanation:

We had been making the glossary itself a list, but that was wrong because he glossary has non-list items in it. This fixes that, and it also makes the behavior of screen readers on key terms significantly better.


In this video, you can see that VoiceOver reads key term pairs as a single unit, as you might expect, and also allows the user to drill down and have it read the term and definition individually.

https://github.com/user-attachments/assets/70194601-4430-44aa-8df4-058a9f5923e4

Part of this fix involved upgrading to PrinceXML 16 since 15 likes to ignore tags on DD/DT elements for some reason. I did some testing to try to find all the differences. That's still ongoing, but I am pretty sure there are no differences.

