### PR TITLE
Align `os-number` right in AP Physics 2e `TestPrep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add margins to numbered lists in `hs-physics` worked examples and snap labs (CORE-1789)
 - Indent question stem lists less in `carnival`
 - Indent first-level lists in eos sections in `corn`
+- Align `os-number` right in AP Physics 2e `TestPrep`
 
 ## [v2.19.0] - 2026-04-15
 

--- a/styles/books/ap-physics-2e/book.scss
+++ b/styles/books/ap-physics-2e/book.scss
@@ -5,6 +5,7 @@
   TestPrep: (
     _selectors: ("[data-type = 'chapter'] > .os-ap-test-prep-container"),
     'ProblemSolutionNumber:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'ProblemSolutionNumber:::text-align': right,
 ),
 ));
 

--- a/styles/output/ap-physics-2e-pdf.css
+++ b/styles/output/ap-physics-2e-pdf.css
@@ -3497,6 +3497,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 
@@ -3543,6 +3544,7 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   text-decoration: none;
   color: #000000;
   font-weight: bold;
+  text-align: right;
   min-width: 24px;
 }
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1795

<img width="615" height="165" alt="Screenshot 2026-05-26 at 2 47 59 PM" src="https://github.com/user-attachments/assets/19b4c91b-490b-40d3-b68a-59340692d3ef" />
