### PR TITLE
Set table width to 95% in `ModuleContainerWithTwoColumns` exercises i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Indent question stem lists less in `carnival`
 - Indent first-level lists in eos sections in `corn`
 - Set table width to 95% in `ModuleContainerWithTwoColumns` exercises in `ap-physics-2e`
-- Use single-column for `ap-test-prep` with tables having five or more columns
+- Use single-column for `ap-test-prep` with tables having six or more columns
 
 ## [v2.19.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add margins to numbered lists in `hs-physics` worked examples and snap labs (CORE-1789)
 - Indent question stem lists less in `carnival`
 - Indent first-level lists in eos sections in `corn`
+- Set table width to 95% in `ModuleContainerWithTwoColumns` exercises in `ap-physics-2e`
 
 ## [v2.19.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Indent question stem lists less in `carnival`
 - Indent first-level lists in eos sections in `corn`
 - Set table width to 95% in `ModuleContainerWithTwoColumns` exercises in `ap-physics-2e`
+- Use single-column for `ap-test-prep` with tables having five or more columns
 
 ## [v2.19.0] - 2026-04-15
 

--- a/styles/books/ap-physics-2e/book.scss
+++ b/styles/books/ap-physics-2e/book.scss
@@ -10,7 +10,9 @@
 
 @include add_settings((
   TwoColumnsModules: (
-    _selectors: ('.os-ap-test-prep-container'),
+    _selectors: ('.os-ap-test-prep-container:not(:has(.os-table > table tr td:nth-of-type(6)))'),
+    'ModuleContainerWithTwoColumnsTable:::width': 95%,
+    'ModuleContainerWithTwoColumnsTable:::margin': auto,
   ),
 ));
 

--- a/styles/designs/carnival/parts/_module-components.scss
+++ b/styles/designs/carnival/parts/_module-components.scss
@@ -10,6 +10,15 @@ $Module__Container--WithTwoColumns: (
     ),
 );
 
+$Module__Container--WithTwoColumns__Table: (
+    _name: "ModuleContainerWithTwoColumnsTable",
+    _subselector: " .os-table > table",
+    _properties: (
+        width: enum('ValueSet:::OPTIONAL'),
+        margin: enum('ValueSet:::OPTIONAL'),
+    )
+);
+
 $ModuleWithIndentation__Para: (
     _name: "ModuleWithIndentationPara",
     _subselector: ' > p',

--- a/styles/designs/carnival/parts/_module-shapes.scss
+++ b/styles/designs/carnival/parts/_module-shapes.scss
@@ -4,7 +4,11 @@
 
 @include create_shape('carnival:::ModuleWithTwoColumnsShape', (
     _components: (
-      $Module__Container--WithTwoColumns
+        map-merge($Module__Container--WithTwoColumns, (
+            _components: (
+                $Module__Container--WithTwoColumns__Table
+            )
+        ))
     )
 ));
 

--- a/styles/output/ap-physics-2e-pdf.css
+++ b/styles/output/ap-physics-2e-pdf.css
@@ -3578,10 +3578,15 @@ h4.os-subtitle + .os-figure:not(.has-splash) > figure {
   width: 100%;
 }
 
-.os-ap-test-prep-container {
+.os-ap-test-prep-container:not(:has(.os-table > table tr td:nth-of-type(6))) {
   column-count: 2;
   column-gap: 2.4rem;
   column-width: auto;
+}
+
+.os-ap-test-prep-container:not(:has(.os-table > table tr td:nth-of-type(6))) .os-table > table {
+  width: 95%;
+  margin: auto;
 }
 
 .os-ap-test-prep-container section {


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1798

<img width="980" height="786" alt="Screenshot 2026-05-27 at 10 57 26 AM" src="https://github.com/user-attachments/assets/14d4bfd1-d87e-499a-872b-50a162c3bf6e" />

<img width="980" height="556" alt="Screenshot 2026-05-27 at 10 19 17 AM" src="https://github.com/user-attachments/assets/900c82fc-48f3-4e07-bd4c-99d9472b90ff" />
