### PR TITLE
Fix chapter intro right margin in `biology`, `ap-biology`, and `neuro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix chapter intro right margin in `biology`, `ap-biology`, and `neuroscience` (reduce page count)
 - Add margins to numbered lists in `hs-physics` worked examples and snap labs (CORE-1789)
 - Keep science-practice single-column for tables with 6+ columns
 - Indent question stem lists less in `carnival`

--- a/styles/books/biology/book.scss
+++ b/styles/books/biology/book.scss
@@ -8,7 +8,7 @@ $PagesWithBands: (
 
 $bandColor: #0074BC;
 
-$ChapterIntroType: side;
+$ChapterIntroType: fullWidth;
 
 @import 'framework/framework';
 @import '../../design-settings/carnival/_design.scss';

--- a/styles/books/neuroscience/book.scss
+++ b/styles/books/neuroscience/book.scss
@@ -6,7 +6,7 @@ $PagesWithBands: (
 
 $bandColor: #0074BC;
 
-$ChapterIntroType: side;
+$ChapterIntroType: fullWidth;
 
 @import 'framework/framework';
 @import '../../design-settings/carnival/_design.scss';

--- a/styles/output/ap-biology-pdf.css
+++ b/styles/output/ap-biology-pdf.css
@@ -943,12 +943,6 @@ div[data-type=composite-page].os-eob {
   margin-bottom: 0.8in;
   margin-top: 0.8in;
 }
-@page chapter:first-of-group {
-  margin-right: 2in;
-}
-@page chapter:nth-of-group(2) {
-  margin-right: 2in;
-}
 :root {
   font-family: IBM Plex Sans, sans-serif;
   font-size: 12px;

--- a/styles/output/biology-pdf.css
+++ b/styles/output/biology-pdf.css
@@ -943,12 +943,6 @@ div[data-type=composite-page].os-eob {
   margin-bottom: 0.8in;
   margin-top: 0.8in;
 }
-@page chapter:first-of-group {
-  margin-right: 2in;
-}
-@page chapter:nth-of-group(2) {
-  margin-right: 2in;
-}
 :root {
   font-family: IBM Plex Sans, sans-serif;
   font-size: 12px;

--- a/styles/output/neuroscience-pdf.css
+++ b/styles/output/neuroscience-pdf.css
@@ -943,12 +943,6 @@ div[data-type=composite-page].os-eob {
   margin-bottom: 0.8in;
   margin-top: 0.8in;
 }
-@page chapter:first-of-group {
-  margin-right: 2in;
-}
-@page chapter:nth-of-group(2) {
-  margin-right: 2in;
-}
 :root {
   font-family: IBM Plex Sans, sans-serif;
   font-size: 12px;


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1808

It looks like this goes all the way back to this PR: https://github.com/openstax/cnx-recipes/pull/2278. Maybe an unfinished feature. I am not honestly sure. Anyway, this was the fix to remove it. Now `$ChapterIntroType: side` path in folio is effectively dead code.