### PR TITLE
Release v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.20.0] - 2026-05-28
+
 - Fix chapter intro right margin in `biology`, `ap-biology`, and `neuroscience` (reduce page count)
 - Add margins to numbered lists in `hs-physics` worked examples and snap labs (CORE-1789)
 - Keep science-practice single-column for tables with 6+ columns


### PR DESCRIPTION
## Summary

Release version 2.20.0 of ce-styles with the following changes:

- Fix chapter intro right margin in `biology`, `ap-biology`, and `neuroscience` (reduce page count)
- Add margins to numbered lists in `hs-physics` worked examples and snap labs (CORE-1789)
- Keep science-practice single-column for tables with 6+ columns
- Indent question stem lists less in `carnival`
- Indent first-level lists in eos sections in `corn`
- Style nested list note titles in `carnival`
- Set table width to 95% in `ModuleContainerWithTwoColumns` exercises in `ap-physics-2e`
- Use single-column for `ap-test-prep` with tables having six or more columns
- Align `os-number` right in AP Physics 2e `TestPrep`

## Changes

- Updated CHANGELOG.md to move all unreleased changes to v2.20.0 section
- Left [Unreleased] section empty as required

## Related Jira Ticket

https://openstax.atlassian.net/browse/CORE-2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)